### PR TITLE
Dotdict

### DIFF
--- a/square.py
+++ b/square.py
@@ -134,30 +134,29 @@ def compute_patch(config, local, server):
         return RetVal(None, True)
 
     try:
-        assert server["apiVersion"] == local["apiVersion"]
-        assert server["kind"] == local["kind"]
-        assert server["metadata"]["name"] == local["metadata"]["name"]
-        if server["kind"] != "Namespace":
-            assert server["metadata"]["namespace"] == local["metadata"]["namespace"]
+        assert server.apiVersion == local.apiVersion
+        assert server.kind == local.kind
+        assert server.metadata.name == local.metadata.name
+        if server.kind != "Namespace":
+            assert server.metadata.namespace == local.metadata.namespace
     except AssertionError:
         logit.error("Cannot compute JSON patch for incompatible manifests")
         return RetVal(None, True)
 
-    kind = server['kind']
-    name = server['metadata']['name']
-    namespace = server['metadata'].get('namespace', None)
+    namespace = server.metadata.get('namespace', None)
 
-    url = urlpath_builder(config, kind, namespace)
+    url = urlpath_builder(config, server.kind, namespace)
 
     patch = jsonpatch.make_patch(server, local)
     patch = json.loads(patch.to_string())
-    full_url = f'{url}/{name}'
+    full_url = f'{url}/{server.metadata.name}'
 
     return RetVal(Patch(full_url, patch), None)
 
 
 def manifest_metaspec(manifest: dict):
     manifest = copy.deepcopy(manifest)
+    manifest = utils.make_dotdict(manifest)
 
     must_have = {'apiVersion', 'kind', 'metadata', 'spec'}
     if not must_have.issubset(set(manifest.keys())):

--- a/square.py
+++ b/square.py
@@ -186,12 +186,11 @@ def manifest_metaspec(manifest: dict):
         logit.error(f"Invalid capitalisation: {manifest.kind}")
         return RetVal(None, True)
 
-    old_meta = manifest.metadata
-    new_meta = {'name': old_meta.name}
-    if 'namespace' in old_meta:
-        new_meta["namespace"] = old_meta.namespace
-    if 'labels' in old_meta:
-        new_meta["labels"] = old_meta.labels
+    new_meta = {'name': manifest.metadata.name}
+    if 'namespace' in manifest.metadata:
+        new_meta["namespace"] = manifest.metadata.namespace
+    if 'labels' in manifest.metadata:
+        new_meta["labels"] = manifest.metadata.labels
 
     ret = {
         'apiVersion': manifest.apiVersion,

--- a/square.py
+++ b/square.py
@@ -166,37 +166,38 @@ def manifest_metaspec(manifest: dict):
         return RetVal(None, True)
     del must_have
 
-    if manifest["kind"] == "Namespace":
-        if "namespace" in manifest["metadata"]:
+    if manifest.kind == "Namespace":
+        if "namespace" in manifest.metadata:
             logit.error("Namespace must not have a `metadata.namespace` attribute")
             return RetVal(None, True)
         must_have = {"name"}
     else:
         must_have = {"name", "namespace"}
 
-    if not must_have.issubset(set(manifest["metadata"].keys())):
-        missing = must_have - set(manifest["metadata"].keys())
+    if not must_have.issubset(set(manifest.metadata.keys())):
+        missing = must_have - set(manifest.metadata.keys())
         logit.error(f"Manifest metadata is missing these keys: {missing}")
         return RetVal(None, True)
+    del must_have
 
-    if manifest["kind"].lower().capitalize() != manifest["kind"]:
-        logit.error(f"Invalid capitalisation: {manifest['kind']}")
+    if manifest.kind.lower().capitalize() != manifest.kind:
+        logit.error(f"Invalid capitalisation: {manifest.kind}")
         return RetVal(None, True)
 
-    old_meta = manifest['metadata']
-    new_meta = {'name': old_meta['name']}
+    old_meta = manifest.metadata
+    new_meta = {'name': old_meta.name}
     if 'namespace' in old_meta:
-        new_meta['namespace'] = old_meta['namespace']
+        new_meta["namespace"] = old_meta.namespace
     if 'labels' in old_meta:
-        new_meta['labels'] = old_meta['labels']
+        new_meta["labels"] = old_meta.labels
 
     ret = {
-        'apiVersion': manifest['apiVersion'],
-        'kind': manifest['kind'],
+        'apiVersion': manifest.apiVersion,
+        'kind': manifest.kind,
         'metadata': new_meta,
-        'spec': manifest['spec'],
+        'spec': manifest.spec,
     }
-    return RetVal(ret, None)
+    return RetVal(utils.make_dotdict(ret), None)
 
 
 def list_parser(manifest_list: dict):

--- a/square.py
+++ b/square.py
@@ -85,6 +85,9 @@ def diff_manifests(src: dict, dst: dict):
     if err:
         return RetVal(None, True)
 
+    # Undo the DotDicts for the YAML parser.
+    src = utils.undo_dotdict(src)
+    dst = utils.undo_dotdict(dst)
     src_lines = yaml.dump(src, default_flow_style=False).splitlines()
     dst_lines = yaml.dump(dst, default_flow_style=False).splitlines()
 
@@ -459,6 +462,8 @@ def load_manifest(fname):
 
 
 def save_manifests(manifests, fname):
+    # Undo the DotDicts for the YAML parser.
+    manifests = utils.undo_dotdict(copy.deepcopy(manifests))
     yaml.safe_dump_all(
         manifests.values(),
         open(fname, 'w'),

--- a/test_k8s_utils.py
+++ b/test_k8s_utils.py
@@ -1,0 +1,77 @@
+import copy
+import k8s_utils as utils
+
+
+class TestBasic:
+    def test_make_dotdict(self):
+        """Create various DotDict instances."""
+
+        # These are not dictionaries but must return a comparable type nevertheless.
+        assert utils.make_dotdict(None) is None
+        assert utils.make_dotdict(3) == 3
+        assert utils.make_dotdict('3') == '3'
+        assert utils.make_dotdict(['3', 3]) == ['3', 3]
+        assert utils.make_dotdict(('3', 3)) == ['3', 3]
+
+        # Valid dict. Verify Dot access.
+        d = utils.make_dotdict({'foo': 'bar'})
+        assert d.foo == 'bar'
+
+        # A list of dicts.
+        d = utils.make_dotdict([{'foo0': 'bar0'}, {'foo1': 'bar1'}])
+        assert d[0].foo0 == 'bar0'
+        assert d[1].foo1 == 'bar1'
+
+        # A dict of dicts.
+        d = utils.make_dotdict({'foo0': {'foo1': 'bar1'}})
+        assert d.foo0.foo1 == 'bar1'
+
+        # The `make_dotdict` function must have operated recursively.
+        assert isinstance(d, utils.DotDict)
+        assert isinstance(d.foo0, utils.DotDict)
+
+    def test_undo_dotdict(self):
+        """Verify that `undo_dotdict` does just that."""
+        # Demo dictionary.
+        src = {'foo0': {'foo1': 'bar1'}}
+        ddict = utils.make_dotdict(src)
+
+        # Converting a DotDict back via `dict` is possible but does not act
+        # recursively.
+        ddict_undo = dict(ddict)
+        assert type(ddict_undo) == dict
+        assert type(ddict_undo["foo0"]) != dict  # <- Still a `DotDict`!
+        assert src == ddict_undo
+        del ddict_undo
+
+        # Exactly the same test, but this time we use the `undo_dotdict`
+        # function which operates recursively and will ensure that the
+        # sub-dicts are also converted back to plain Python dicts.
+        ddict_undo = utils.undo_dotdict(ddict)
+        assert type(ddict_undo) == dict
+        assert type(ddict_undo["foo0"]) == dict  # <- Now a plain `dict`!
+        assert src == ddict_undo
+
+    def test_make_dotdict_deepcopy(self):
+        """Verify that it is possible to copy DotDict instances."""
+        # Demo dictionary.
+        src = {'foo0': {'foo1': 'bar1'}}
+
+        # DotDict must test positive for equality.
+        ddict = utils.make_dotdict(src)
+        assert isinstance(ddict, utils.DotDict)
+        assert isinstance(ddict.foo0, utils.DotDict)
+        assert src == ddict
+
+        # Deepcopy must work.
+        ddict2 = copy.deepcopy(ddict)
+        ddict3 = copy.deepcopy(ddict2)
+        assert src == ddict2 == ddict3
+        assert isinstance(ddict, utils.DotDict)
+        assert isinstance(ddict2, utils.DotDict)
+        assert ddict is not ddict2
+        assert ddict is not ddict3
+
+        # Normal copy must work.
+        ddict4 = copy.copy(ddict)
+        assert src == ddict4


### PR DESCRIPTION
Use `DotDict` to access fields in manifests via `.` instead of full Python dict lookups.

For instance, use `manifest.meta.name` instead of `manifest["meta"]["name"]`.

This improves the code readability but, as it turned out, also make JSON/YAML serialisation a bit of a nuisance. I will keep the PR for now. If it proves too much of a hassle I will remove it again.
