### PR TITLE
11 PoC

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ pytest = "*"
 pyyaml = "==4.2b4"
 requests = "*"
 requests-mock = "*"
+pytest-cov = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "21442054835aadb776a5137605d6fcff2d37600ce83843b371fa6470f2766612"
+            "sha256": "88bf2ae9a08e7e83cf305330039e44311b9bb8bce7727618faf570f119beeafb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,10 +47,10 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:0a258d82933a1dd18cb540aca4ac5d5690731e24d1239a08577b814998f49785",
-                "sha256:4621965b0d9d4c82a79a29edbad19946f5e7702df4afae7d1ed2df951559a8cc"
+                "sha256:219b7dc6024195b6f2bc3d3f884d1fef458745cd323b04165378622dcc823852",
+                "sha256:9efcc9fab3b49ab833475702b55edd5ae07af1af7a4c627678980b45e459c460"
             ],
-            "version": "==3.0.0"
+            "version": "==3.1.0"
         },
         "certifi": {
             "hashes": [
@@ -74,12 +74,48 @@
             "index": "pypi",
             "version": "==0.4.1"
         },
+        "coverage": {
+            "hashes": [
+                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
+                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
+                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
+                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
+                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
+                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
+                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
+                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
+                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
+                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
+                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
+                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
+                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
+                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
+                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
+                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
+                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
+                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
+                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
+                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
+                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
+                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
+                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
+                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
+                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
+                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
+                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
+                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
+                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
+                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
+                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+            ],
+            "version": "==4.5.2"
+        },
         "decorator": {
             "hashes": [
-                "sha256:2c51dff8ef3c447388fe5e4453d24a2bf128d3a4c32af3fabef1f01c6851ab82",
-                "sha256:c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c"
+                "sha256:33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e",
+                "sha256:cabb249f4710888a2fc0e13e9a16c343d932033718ff62e1e9bc93a9d3a9122b"
             ],
-            "version": "==4.3.0"
+            "version": "==4.3.2"
         },
         "flake8": {
             "hashes": [
@@ -106,11 +142,11 @@
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:301e498ae5152250b7f3c2dc091ee383c2852ef90aeab12bb29767ef9981627c",
-                "sha256:9106e7d09d80f59a9472a91edd85c2d6ad420aef28c9440ce1691b4a19ba9ada"
+                "sha256:06907006ed5ce831018f03af3852d739c0b2489cdacfda6971bcc2075c762858",
+                "sha256:937eabdc3940977f712fa648a096a5142766b6d0a0f58bc603e2ac0687397ef0"
             ],
             "index": "pypi",
-            "version": "==1.7.7"
+            "version": "==1.7.8"
         },
         "google-auth": {
             "hashes": [
@@ -202,10 +238,10 @@
         },
         "parso": {
             "hashes": [
-                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
-                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
+                "sha256:4b8f9ed80c3a4a3191aa3261505d868aa552dd25649cb13a7d73b6b7315edf2d",
+                "sha256:5a120be2e8863993b597f1c0437efca799e90e0793c98ae5d4e34ebd00140e31"
             ],
-            "version": "==0.3.1"
+            "version": "==0.3.2"
         },
         "pexpect": {
             "hashes": [
@@ -231,11 +267,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:c1d6aff5252ab2ef391c2fe498ed8c088066f66bc64a8d5c095bbf795d9fec34",
-                "sha256:d4c47f79b635a0e70b84fdb97ebd9a274203706b1ee5ed44c10da62755cf3ec9",
-                "sha256:fd17048d8335c1e6d5ee403c3569953ba3eb8555d710bfc548faf0712666ea39"
+                "sha256:88002cc618cacfda8760c4539e76c3b3f148ecdb7035a3d422c7ecdc90c2a3ba",
+                "sha256:c6655a12e9b08edb8cf5aeab4815fd1e1bdea4ad73d3bbf269cf2e0c4eb75d5e",
+                "sha256:df5835fb8f417aa55e5cafadbaeb0cf630a1e824aad16989f9f0493e679ec010"
             ],
-            "version": "==2.0.7"
+            "version": "==2.0.8"
         },
         "ptyprocess": {
             "hashes": [
@@ -260,10 +296,10 @@
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:642afdabb681d39f5948fd5477764d94faf17ce40e5691e9998b52815fbb4e71",
-                "sha256:d14fcb29dabecba3d7b360bf72327c26c385248a5d603cf6be5f566ce999b261"
+                "sha256:79580acf813e3b7d6e69783884e6e83ac94bf4617b36a135b85c599d8a818a7b",
+                "sha256:a52090e8c5841ebbf08ae455146792d9ef3e8445b21055d3a3b7ed9c712b7c7c"
             ],
-            "version": "==0.2.3"
+            "version": "==0.2.4"
         },
         "pycodestyle": {
             "hashes": [
@@ -293,6 +329,14 @@
             ],
             "index": "pypi",
             "version": "==4.1.1"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
+                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
+            ],
+            "index": "pypi",
+            "version": "==2.6.1"
         },
         "pyyaml": {
             "hashes": [
@@ -337,17 +381,17 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:10687fc53eeb3518e01a0ac84d3d711da623d3298a3039459d3f649927c4a270",
-                "sha256:b23a0d7da0247200fe83c67c34de9d7599ad404106367313d8e65e04174d0b4b"
+                "sha256:466910df7561796a60748826781ebe9a888f7a1668a636ae86783f44d10aae73",
+                "sha256:87db12ae79194f0ff9808d2b1641c4f031ae39ffa3cab6b907ea7c1e5e5ed445"
             ],
-            "version": "==1.7.2"
+            "version": "==1.7.3"
         },
         "testfixtures": {
             "hashes": [
-                "sha256:969e967df5d8e12012b5c90986428919b1068c20841b0077b3e29e9a928605d3",
-                "sha256:b6c05222ce8d3c34a1353ff30c73da55f61ef58153229a5664ef7110ec340cdd"
+                "sha256:59df1b51118978400d9926d5c1efb295f900ae626a54113323732647e453a80f",
+                "sha256:cbd0f095d178de578709bcf4cc6eea896964635d2b41386d1cc7583674809b0e"
             ],
-            "version": "==6.4.3"
+            "version": "==6.5.0"
         },
         "traitlets": {
             "hashes": [

--- a/manio.py
+++ b/manio.py
@@ -67,7 +67,7 @@ def unparse(file_manifests):
     return RetVal(out, False)
 
 
-def save(folder, data: dict):
+def save_files(folder, data: dict):
     for fname, yaml_str in data.items():
         fname = os.path.join(folder, fname)
         path, _ = os.path.split(fname)
@@ -78,7 +78,7 @@ def save(folder, data: dict):
     return RetVal(None, False)
 
 
-def load(folder, fnames: str):
+def load_files(folder, fnames: str):
     out = {}
     for fname_rel in fnames:
         fname_abs = os.path.join(folder, fname_rel)

--- a/manio.py
+++ b/manio.py
@@ -163,16 +163,11 @@ def unparse(file_manifests):
         Dict[Filename:YamlStr]: Yaml representation of all manifests.
 
     """
-    # Group the manifest kinds in this order.
-    # Fixme: import this from a global variable in `square.py` that specifies
-    #        the resource kinds we support.
-    supported_kinds = ("Namespace", "Service", "Deployment")
-
     out = {}
     for fname, manifests in file_manifests.items():
         # Verify that this file contains only supported resource kinds.
         kinds = {meta.kind for meta, _ in manifests}
-        diff = kinds - set(supported_kinds)
+        diff = kinds - set(square.SUPPORTED_KINDS)
         if len(diff) > 0:
             logit.error(f"Found unsupported resource kinds when writing <{fname}>: {diff}")
             return RetVal(None, True)
@@ -180,7 +175,7 @@ def unparse(file_manifests):
         # Group the manifests by their "kind", sort each group and compile a
         # new list of grouped and sorted manifests.
         man_sorted = []
-        for kind in supported_kinds:
+        for kind in square.SUPPORTED_KINDS:
             man_sorted += sorted([_ for _ in manifests if _[0].kind == kind])
         assert len(man_sorted) == len(manifests)
 

--- a/manio.py
+++ b/manio.py
@@ -131,10 +131,14 @@ def sync(local_manifests, server_manifests):
             # Find out the YAML document index and file that defined `meta`.
             fname, idx = meta_to_fname[meta]
         except KeyError:
-            # Put the resource into a "catch-all" file for its namespace. This
-            # is necessary because none of the existing YAML files defined that
-            # resource.
-            out_add_mod[f"_{meta.namespace}.yaml"].append((meta, manifest))
+            # Put the resource into the correct "catch-all" file. However, we
+            # first need to determine the namespace, which differs depending on
+            # whether the resource is a Namespace or other resource.
+            if meta.kind == "Namespace":
+                catch_all = f"_{meta.name}.yaml"
+            else:
+                catch_all = f"_{meta.namespace}.yaml"
+            out_add_mod[catch_all].append((meta, manifest))
         else:
             # Update the correct YAML document in the correct file.
             out_add_mod[fname][idx] = (meta, manifest)

--- a/manio.py
+++ b/manio.py
@@ -4,6 +4,7 @@ import copy
 
 import square
 import yaml
+import k8s_utils
 
 from square import RetVal
 
@@ -85,3 +86,16 @@ def load_files(folder, fnames: str):
         logit.debug(f"Loading {fname_abs}")
         out[fname_rel] = open(fname_abs, "r").read()
     return RetVal(out, False)
+
+
+def load(folder):
+    fnames = glob.glob(os.path.join(folder, "**", "*.yaml"), recursive=True)
+    fnames = [_[len(folder) + 1:] for _ in fnames]
+    fdata_raw, err = load_files(folder, fnames)
+    return parse(fdata_raw)
+
+
+def save(folder, manifests: dict):
+    manifests = k8s_utils.undo_dotdict(manifests)
+    fdata_raw, err = unparse(manifests)
+    return save_files(folder, fdata_raw)

--- a/manio.py
+++ b/manio.py
@@ -1,5 +1,6 @@
+import glob
+import os
 import copy
-import collections
 
 import square
 import yaml
@@ -59,4 +60,18 @@ def unparse(file_manifests):
     }
     out = {k: v for k, v in out.items() if len(v) > 0}
     out = {k: yaml.safe_dump_all(v) for k, v in out.items()}
+    return RetVal(out, False)
+
+
+def save(data: dict):
+    for fname, yaml_str in data.items():
+        open(fname, 'w').write(yaml_str)
+    return RetVal(None, False)
+
+
+def load(fnames: str):
+    out = {}
+    for fname in fnames:
+        assert os.path.exists(fname)
+        out[fname] = open(fname, "r").read()
     return RetVal(out, False)

--- a/manio.py
+++ b/manio.py
@@ -315,8 +315,10 @@ def load(folder):
     # relative to `folder`.
     fnames = [_.relative_to(folder) for _ in folder.rglob("*.yaml")]
 
-    # Load the files.
+    # Load the files and abort on error.
     fdata_raw, err = load_files(folder, fnames)
+    if err:
+        return RetVal(None, True)
 
     # Return the YAML parsed manifests.
     return parse(fdata_raw)
@@ -343,5 +345,10 @@ def save(folder, manifests: dict):
     # Python's `pathlib.Path` objects are simply nicer to work with...
     folder = pathlib.Path(folder)
 
+    # Convert the manifest to YAML strings. Abort on error.
     fdata_raw, err = unparse(manifests)
+    if err:
+        return RetVal(None, True)
+
+    # Save the files to disk.
     return save_files(folder, fdata_raw)

--- a/manio.py
+++ b/manio.py
@@ -291,16 +291,55 @@ def load_files(base_path, fnames: tuple):
 
 
 def load(folder):
+    """Load all "*.yaml" files under `folder` (recursively).
+
+    Ignores all files not ending in ".yaml".
+
+    Returns no data in the case of an error.
+
+    NOTE: this is merely a wrapper around the various low-level functions to
+    load and parse the YAML files.
+
+    Input:
+        folder: str|Path
+            Source folder.
+
+    Returns:
+        Dict[Filename, Tuple(MetaManifest, dict)]: parsed YAML files.
+
+    """
     # Python's `pathlib.Path` objects are simply nicer to work with...
     folder = pathlib.Path(folder)
 
-    fnames = folder.rglob("*.yaml")
-    fnames = [_.relative_to(folder) for _ in fnames]
+    # Compile the list of all YAML files in `folder` but only store their path
+    # relative to `folder`.
+    fnames = [_.relative_to(folder) for _ in folder.rglob("*.yaml")]
+
+    # Load the files.
     fdata_raw, err = load_files(folder, fnames)
+
+    # Return the YAML parsed manifests.
     return parse(fdata_raw)
 
 
 def save(folder, manifests: dict):
+    """Convert all `manifests` to YAML and save them.
+
+    Returns no data in the case of an error.
+
+    NOTE: this is merely a wrapper around the various low-level functions to
+    create YAML string and save the files.
+
+    Input:
+        folder: str|Path
+            Source folder.
+        file_manifests: Dict[Filename, Tuple(MetaManifest, dict)]
+            Names of files and their Python dicts to save as YAML.
+
+    Returns:
+        None
+
+    """
     # Python's `pathlib.Path` objects are simply nicer to work with...
     folder = pathlib.Path(folder)
 

--- a/manio.py
+++ b/manio.py
@@ -1,0 +1,62 @@
+import copy
+import collections
+
+import square
+import yaml
+
+from square import RetVal
+
+
+def parse(data: dict):
+    out = {}
+    for fname, yaml_str in data.items():
+        manifests = yaml.safe_load_all(yaml_str)
+        out[fname] = []
+        for manifest in manifests:
+            key = square.make_meta(manifest)
+            out[fname].append((key, manifest))
+    return RetVal(out, False)
+
+
+def unpack(data: dict):
+    out = {k: v for fname in data for k, v in data[fname]}
+    return RetVal(out, False)
+
+
+def sync(local_manifests, server_manifests):
+    meta_to_fname = {}
+    for fname in local_manifests:
+        for idx, (meta, _) in enumerate(local_manifests[fname]):
+            meta_to_fname[meta] = (fname, idx)
+            del meta
+        del fname
+
+    # Make a copy of the local manifests so we can safely overwrite the local
+    # manifests with the server ones.
+    out = copy.deepcopy(local_manifests)
+    out["default.yaml"] = []
+    for meta, manifest in server_manifests.items():
+        try:
+            fname, idx = meta_to_fname[meta]
+            out[fname][idx] = (meta, manifest)
+        except KeyError:
+            out["default.yaml"].append((meta, manifest))
+
+    # Remove all the manifests that exist locally but not on the server
+    # anymore.
+    out2 = {}
+    for fname, manifests in out.items():
+        pruned = [_ for _ in manifests if _[0] in server_manifests]
+        out2[fname] = pruned
+
+    return RetVal(out2, False)
+
+
+def unparse(file_manifests):
+    out = {
+        fname: [manifest for _, manifest in manifests]
+        for fname, manifests in file_manifests.items()
+    }
+    out = {k: v for k, v in out.items() if len(v) > 0}
+    out = {k: yaml.safe_dump_all(v) for k, v in out.items()}
+    return RetVal(out, False)

--- a/manio.py
+++ b/manio.py
@@ -245,16 +245,13 @@ def save_files(base_path, file_data: dict):
         fname_abs = base_path / fname
         logit.debug(f"Creating path for <{fname}>")
 
-        # Create the necessary parent directories so we can write the file
-        # afterwards.
-        fname_abs.parent.mkdir(parents=True, exist_ok=True)
+        # Create the parent directories and write the file. Abort on error.
         logit.debug(f"Saving YAML file <{fname_abs}>")
-
-        # Write the file. Abort on error.
         try:
+            fname_abs.parent.mkdir(parents=True, exist_ok=True)
             fname_abs.write_text(yaml_str)
-        except FileNotFoundError:
-            logit.error(f"Could not find <{fname_abs}>")
+        except IOError as err:
+            logit.error(f"{err}")
             return RetVal(None, True)
 
     # Tell caller that all files were successfully written.

--- a/manio.py
+++ b/manio.py
@@ -227,8 +227,16 @@ def save_files(base_path, file_data: dict):
     # Python's `pathlib.Path` objects are simply nicer to work with...
     base_path = pathlib.Path(base_path)
 
+    # Delete all YAML files under `base_path`. This avoid stale manifests.
+    for fp in base_path.rglob("*.yaml"):
+        fp.unlink()
+
     # Iterate over the dict and write each file. Abort on error.
     for fname, yaml_str in file_data.items():
+        # Skip the file if its content would be empty.
+        if yaml_str == '':
+            continue
+
         # Construct absolute file path.
         fname_abs = base_path / fname
         logit.debug(f"Creating path for <{fname}>")

--- a/manio.py
+++ b/manio.py
@@ -291,12 +291,18 @@ def load_files(base_path, fnames: tuple):
 
 
 def load(folder):
-    fnames = glob.glob(os.path.join(folder, "**", "*.yaml"), recursive=True)
-    fnames = [_[len(folder) + 1:] for _ in fnames]
+    # Python's `pathlib.Path` objects are simply nicer to work with...
+    folder = pathlib.Path(folder)
+
+    fnames = folder.rglob("*.yaml")
+    fnames = [_.relative_to(folder) for _ in fnames]
     fdata_raw, err = load_files(folder, fnames)
     return parse(fdata_raw)
 
 
 def save(folder, manifests: dict):
+    # Python's `pathlib.Path` objects are simply nicer to work with...
+    folder = pathlib.Path(folder)
+
     fdata_raw, err = unparse(manifests)
     return save_files(folder, fdata_raw)

--- a/manio.py
+++ b/manio.py
@@ -65,6 +65,8 @@ def unparse(file_manifests):
 
 def save(data: dict):
     for fname, yaml_str in data.items():
+        path, _ = os.path.split(fname)
+        os.makedirs(path, exist_ok=True)
         open(fname, 'w').write(yaml_str)
     return RetVal(None, False)
 

--- a/manio.py
+++ b/manio.py
@@ -64,7 +64,8 @@ def unparse(file_manifests):
         for fname, manifests in file_manifests.items()
     }
     out = {k: v for k, v in out.items() if len(v) > 0}
-    out = {k: yaml.safe_dump_all(v) for k, v in out.items()}
+    out = {k: k8s_utils.undo_dotdict(v) for k, v in out.items()}
+    out = {k: yaml.safe_dump_all(v, default_flow_style=False) for k, v in out.items()}
     return RetVal(out, False)
 
 
@@ -96,6 +97,5 @@ def load(folder):
 
 
 def save(folder, manifests: dict):
-    manifests = k8s_utils.undo_dotdict(manifests)
     fdata_raw, err = unparse(manifests)
     return save_files(folder, fdata_raw)

--- a/square.py
+++ b/square.py
@@ -1,4 +1,3 @@
-import glob
 import manio
 import logging
 import sys

--- a/square.py
+++ b/square.py
@@ -456,25 +456,6 @@ def print_deltas(plan):
     return RetVal(None, None)
 
 
-def load_manifest(fname):
-    raw = yaml.safe_load_all(open(fname))
-    manifests = {}
-
-    for manifest in raw:
-        manifests[make_meta(manifest)] = copy.deepcopy(manifest)
-    return manifests
-
-
-def save_manifests(manifests, fname):
-    # Undo the DotDicts for the YAML parser.
-    manifests = utils.undo_dotdict(copy.deepcopy(manifests))
-    yaml.safe_dump_all(
-        manifests.values(),
-        open(fname, 'w'),
-        default_flow_style=False,
-    )
-
-
 def get_k8s_version(config: utils.Config, client):
     """Return new `config` with version number of K8s API.
 

--- a/square.py
+++ b/square.py
@@ -17,6 +17,10 @@ import colorama
 from pprint import pprint
 
 
+# We support these resource types. The order matters because it determines the
+# order in which the manifests will be grouped in the output files.
+SUPPORTED_KINDS = ("Namespace", "Service", "Deployment")
+
 Patch = collections.namedtuple('Patch', 'url ops')
 RetVal = collections.namedtuple('RetVal', 'data err')
 DeploymentPlan = collections.namedtuple('DeploymentPlan', 'create patch delete')
@@ -591,7 +595,7 @@ def main():
 
     # Hard coded variables due to lacking of command line support.
     manifest_folder = "manifests"
-    kinds = ('namespace', 'service', 'deployment')
+    kinds = SUPPORTED_KINDS
     namespace = None
 
     fdata_meta, err = manio.load(manifest_folder)

--- a/square.py
+++ b/square.py
@@ -599,16 +599,14 @@ def main():
     manifest_folder = "manifests"
 
     if param.parser == "get":
-        fnames = glob.glob(os.path.join(manifest_folder, "**", "*.yaml"), recursive=True)
-        fnames = [_[len(manifest_folder) + 1:] for _ in fnames]
-        fdata_raw, err = manio.load_files(manifest_folder, fnames)
-        fdata_meta, err = manio.parse(fdata_raw)
+        fdata_meta, err = manio.load(manifest_folder)
+
         local_manifests, err = manio.unpack(fdata_meta)
+
         server_manifests, err = download_manifests(config, client, kinds, namespace)
         updated_manifests, err = manio.sync(fdata_meta, server_manifests)
-        updated_manifests = utils.undo_dotdict(updated_manifests)
-        fdata_raw, err = manio.unparse(updated_manifests)
-        _, err = manio.save_files(manifest_folder, fdata_raw)
+
+        _, err = manio.save(manifest_folder, updated_manifests)
     elif param.parser == "diff":
         local_manifests = load_manifest(fname)
         server_manifests, _ = download_manifests(config, client, kinds, namespace)

--- a/square.py
+++ b/square.py
@@ -601,14 +601,14 @@ def main():
     if param.parser == "get":
         fnames = glob.glob(os.path.join(manifest_folder, "**", "*.yaml"), recursive=True)
         fnames = [_[len(manifest_folder) + 1:] for _ in fnames]
-        fdata_raw, err = manio.load(manifest_folder, fnames)
+        fdata_raw, err = manio.load_files(manifest_folder, fnames)
         fdata_meta, err = manio.parse(fdata_raw)
         local_manifests, err = manio.unpack(fdata_meta)
         server_manifests, err = download_manifests(config, client, kinds, namespace)
         updated_manifests, err = manio.sync(fdata_meta, server_manifests)
         updated_manifests = utils.undo_dotdict(updated_manifests)
         fdata_raw, err = manio.unparse(updated_manifests)
-        _, err = manio.save(manifest_folder, fdata_raw)
+        _, err = manio.save_files(manifest_folder, fdata_raw)
     elif param.parser == "diff":
         local_manifests = load_manifest(fname)
         server_manifests, _ = download_manifests(config, client, kinds, namespace)

--- a/test_manio.py
+++ b/test_manio.py
@@ -89,12 +89,16 @@ class TestYamlManifestIO:
         # Expected output after we merged back the changes (ie `dply[1]` is
         # different, `dply[{3,5}]` were deleted and `dply[{6,7}]` are new).
         # The new manifests must all end up in "default.yaml".
-        fdata_test_out = {
-            "m0.yaml": yaml.safe_dump_all([dply[0], server_manifests[meta[1]], dply[2]]),
-            "m1.yaml": yaml.safe_dump_all([dply[4]]),
-            "default.yaml": yaml.safe_dump_all([dply[6], dply[7]]),
+        expected = {
+            "m0.yaml": [dply[0], server_manifests[meta[1]], dply[2]],
+            "m1.yaml": [dply[4]],
+            "default.yaml": [dply[6], dply[7]],
         }
-        assert fdata_raw_new == fdata_test_out
+        expected = {
+            k: yaml.safe_dump_all(v, default_flow_style=False)
+            for k, v in expected.items()
+        }
+        assert fdata_raw_new == expected
 
     def test_load_and_save_single_dir(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/test_manio.py
+++ b/test_manio.py
@@ -84,17 +84,17 @@ class TestYamlManifestIO:
                 "m1.yaml": "something 1",
                 "m2.yaml": "something 2",
             }
-            fdata_test_in = {pjoin(tempdir, k): v for k, v in fdata_test_in.items()}
-            fnames = list(fdata_test_in.keys())
+            fnames_rel = list(fdata_test_in.keys())
+            fnames_abs = [pjoin(tempdir, _) for _ in fnames_rel]
 
             pattern = os.path.join(tempdir, "**", "*.yaml")
             assert glob.glob(pattern, recursive=True) == []
-            assert manio.save(fdata_test_in) == RetVal(None, False)
-            assert set(glob.glob(pattern, recursive=True)) == set(fnames)
+            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
+            assert set(glob.glob(pattern, recursive=True)) == set(fnames_abs)
 
             # Load files.
             # :: List[Filename] -> Dict[Filename:YamlStr]
-            fdata_raw, err = manio.load(fnames)
+            fdata_raw, err = manio.load(tempdir, fnames_rel)
             assert err is False
             assert fdata_raw == fdata_test_in
 
@@ -106,16 +106,16 @@ class TestYamlManifestIO:
                 "bar/m2.yaml": "something 2",
                 "foo/bar/blah/m2.yaml": "something 3",
             }
-            fdata_test_in = {pjoin(tempdir, k): v for k, v in fdata_test_in.items()}
-            fnames = list(fdata_test_in.keys())
+            fnames_rel = list(fdata_test_in.keys())
+            fnames_abs = [pjoin(tempdir, _) for _ in fnames_rel]
 
             pattern = os.path.join(tempdir, "**", "*.yaml")
             assert glob.glob(pattern, recursive=True) == []
-            assert manio.save(fdata_test_in) == RetVal(None, False)
-            assert set(glob.glob(pattern, recursive=True)) == set(fnames)
+            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
+            assert set(glob.glob(pattern, recursive=True)) == set(fnames_abs)
 
             # Load files.
             # :: List[Filename] -> Dict[Filename:YamlStr]
-            fdata_raw, err = manio.load(fnames)
+            fdata_raw, err = manio.load(tempdir, fnames_rel)
             assert err is False
             assert fdata_raw == fdata_test_in

--- a/test_manio.py
+++ b/test_manio.py
@@ -311,6 +311,17 @@ class TestYamlManifestIO:
             file_manifests = {"m0.yaml": [(mm(kind, "name", "ns"), "0")]}
             assert manio.unparse(file_manifests) == RetVal(None, True)
 
+    def test_unparse_known_kinds(self):
+        """Must handle all known resource kinds without error."""
+        # Convenience.
+        def mm(*args):
+            return square.make_meta(test_square.make_manifest(*args))
+
+        # Test function must gracefully reject all invalid kinds.
+        for kind in square.SUPPORTED_KINDS:
+            file_manifests = {"m0.yaml": [(mm(kind, "name", "ns"), "0")]}
+            assert manio.unparse(file_manifests).err is False
+
     def test_manifest_lifecycle(self):
         """Load, sync and save manifests the hard way.
 

--- a/test_manio.py
+++ b/test_manio.py
@@ -5,6 +5,7 @@ import manio
 import square
 import test_square
 
+import unittest.mock as mock
 from square import RetVal
 
 
@@ -441,3 +442,15 @@ class TestYamlManifestIOIntegration:
         # the `fdata_test_in` dict.
         fnames_abs = {str(tmp_path / fname) for fname in fdata_test_in.keys()}
         assert set(str(_) for _ in tmp_path.rglob("*.yaml")) == fnames_abs
+
+    @mock.patch.object(manio, "load_files")
+    def test_load_err(self, m_load, tmp_path):
+        """Simulate an error in `load_files` function."""
+        m_load.return_value = RetVal(None, True)
+        assert manio.load(tmp_path) == RetVal(None, True)
+
+    @mock.patch.object(manio, "unparse")
+    def test_save_err(self, m_unparse, tmp_path):
+        """Simulate an error in `unparse` function."""
+        m_unparse.return_value = RetVal(None, True)
+        assert manio.save(tmp_path, "foo") == RetVal(None, True)

--- a/test_manio.py
+++ b/test_manio.py
@@ -287,20 +287,18 @@ class TestYamlManifestIO:
             return square.make_meta(test_square.make_manifest(*args))
 
         # Create valid MetaManifests.
-        meta_ns_a = [mm("Namespace", f"d_{_}", "a") for _ in range(10)]
+        meta_ns_a = mm("Namespace", None, "a")
+        meta_ns_b = mm("Namespace", None, "b")
         meta_svc_a = [mm("Service", f"d_{_}", "a") for _ in range(10)]
         meta_dply_a = [mm("Deployment", f"d_{_}", "a") for _ in range(10)]
-        meta_ns_b = [mm("Namespace", f"d_{_}", "b") for _ in range(10)]
         meta_svc_b = [mm("Service", f"d_{_}", "b") for _ in range(10)]
         meta_dply_b = [mm("Deployment", f"d_{_}", "b") for _ in range(10)]
 
         # Define manifests in the correctly grouped and sorted order for three
         # YAML files.
         sorted_manifests_1 = [
-            (meta_ns_a[0], "ns_a_0"),
-            (meta_ns_a[1], "ns_a_1"),
-            (meta_ns_b[0], "ns_b_0"),
-            (meta_ns_b[1], "ns_b_1"),
+            (meta_ns_a, "ns_a"),
+            (meta_ns_b, "ns_b"),
             (meta_svc_a[0], "svc_a_0"),
             (meta_svc_a[1], "svc_a_1"),
             (meta_svc_b[0], "svc_b_0"),
@@ -317,7 +315,7 @@ class TestYamlManifestIO:
             (meta_dply_b[1], "dply_b_1"),
         ]
         sorted_manifests_3 = [
-            (meta_ns_a[0], "ns_a_0"),
+            (meta_ns_a, "ns_a"),
             (meta_svc_b[0], "svc_b_0"),
             (meta_dply_a[1], "dply_a_1"),
         ]

--- a/test_manio.py
+++ b/test_manio.py
@@ -17,6 +17,25 @@ def mk_deploy(name: str):
 
 
 class TestYamlManifestIO:
+    def test_integration(self):
+        # Setup test.
+        dply = [mk_deploy(f"d_{_}") for _ in range(10)]
+        meta = [square.make_meta(_) for _ in dply]
+        fdata_test_in = {
+            "m0.yaml": [(meta[0], dply[0]), (meta[1], dply[1])],
+            "foo/m1.yaml": [(meta[2], dply[2])],
+        }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            pattern = os.path.join(tempdir, "**", "*.yaml")
+            assert glob.glob(pattern, recursive=True) == []
+            fnames_abs = {pjoin(tempdir, _) for _ in fdata_test_in.keys()}
+
+            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
+            assert manio.load(tempdir) == RetVal(fdata_test_in, False)
+
+            assert set(glob.glob(pattern, recursive=True)) == fnames_abs
+
     def test_manifest_lifecycle(self):
         # Setup test.
         dply = [mk_deploy(f"d_{_}") for _ in range(10)]

--- a/test_manio.py
+++ b/test_manio.py
@@ -77,7 +77,7 @@ class TestYamlManifestIO:
         }
         assert fdata_raw_new == fdata_test_out
 
-    def test_load_and_save(self):
+    def test_load_and_save_single_dir(self):
         with tempfile.TemporaryDirectory() as tempdir:
             fdata_test_in = {
                 "m0.yaml": "something 0",
@@ -87,9 +87,32 @@ class TestYamlManifestIO:
             fdata_test_in = {pjoin(tempdir, k): v for k, v in fdata_test_in.items()}
             fnames = list(fdata_test_in.keys())
 
-            assert glob.glob(pjoin(tempdir, "*.yaml")) == []
+            pattern = os.path.join(tempdir, "**", "*.yaml")
+            assert glob.glob(pattern, recursive=True) == []
             assert manio.save(fdata_test_in) == RetVal(None, False)
-            assert glob.glob(pjoin(tempdir, "*.yaml")) == fnames
+            assert set(glob.glob(pattern, recursive=True)) == set(fnames)
+
+            # Load files.
+            # :: List[Filename] -> Dict[Filename:YamlStr]
+            fdata_raw, err = manio.load(fnames)
+            assert err is False
+            assert fdata_raw == fdata_test_in
+
+    def test_load_and_save_sub_dir(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            fdata_test_in = {
+                "m0.yaml": "something 0",
+                "foo/m1.yaml": "something 1",
+                "bar/m2.yaml": "something 2",
+                "foo/bar/blah/m2.yaml": "something 3",
+            }
+            fdata_test_in = {pjoin(tempdir, k): v for k, v in fdata_test_in.items()}
+            fnames = list(fdata_test_in.keys())
+
+            pattern = os.path.join(tempdir, "**", "*.yaml")
+            assert glob.glob(pattern, recursive=True) == []
+            assert manio.save(fdata_test_in) == RetVal(None, False)
+            assert set(glob.glob(pattern, recursive=True)) == set(fnames)
 
             # Load files.
             # :: List[Filename] -> Dict[Filename:YamlStr]

--- a/test_manio.py
+++ b/test_manio.py
@@ -483,8 +483,8 @@ class TestYamlManifestIOIntegration:
             assert fp.exists()
             assert fp.read_text() == file_data[fname]
 
-        # Saving to non-writable folder must fail.
-        assert manio.save_files("/proc", file_data) == RetVal(None, True)
+        # Saving to non-writable (or non-existing) folder must fail.
+        assert manio.save_files("/does/not/exist", file_data) == RetVal(None, True)
 
     def test_load_save_ok(self, tmp_path):
         """Basic test that uses the {load,save} convenience functions."""

--- a/test_manio.py
+++ b/test_manio.py
@@ -443,6 +443,11 @@ class TestYamlManifestIOIntegration:
         fnames_abs = {str(tmp_path / fname) for fname in fdata_test_in.keys()}
         assert set(str(_) for _ in tmp_path.rglob("*.yaml")) == fnames_abs
 
+        # Create non-YAML files. The `load_files` function must skip those.
+        (tmp_path / "delme.txt").touch()
+        (tmp_path / "foo" / "delme.txt").touch()
+        assert manio.load(tmp_path) == RetVal(fdata_test_in, False)
+
     @mock.patch.object(manio, "load_files")
     def test_load_err(self, m_load, tmp_path):
         """Simulate an error in `load_files` function."""

--- a/test_manio.py
+++ b/test_manio.py
@@ -1,7 +1,4 @@
 import random
-import os
-import glob
-import tempfile
 
 import yaml
 import manio
@@ -9,8 +6,6 @@ import square
 import test_square
 
 from square import RetVal
-
-pjoin = os.path.join
 
 
 def mk_deploy(name: str, ns: str="namespace"):
@@ -438,13 +433,11 @@ class TestYamlManifestIOIntegration:
         }
         del dply, meta
 
-        # Save test file in temporary folder.
-        fnames_abs = {pjoin(tmp_path, _) for _ in fdata_test_in.keys()}
-
         # Save the test data, then load it back and verify.
         assert manio.save(tmp_path, fdata_test_in) == RetVal(None, False)
         assert manio.load(tmp_path) == RetVal(fdata_test_in, False)
 
-        # Use `glob` to verify the files ended up in the correct location.
-        pattern = os.path.join(tmp_path, "**", "*.yaml")
-        assert set(glob.glob(pattern, recursive=True)) == fnames_abs
+        # Glob the folder and ensure it contains exactly the files specified in
+        # the `fdata_test_in` dict.
+        fnames_abs = {str(tmp_path / fname) for fname in fdata_test_in.keys()}
+        assert set(str(_) for _ in tmp_path.rglob("*.yaml")) == fnames_abs

--- a/test_manio.py
+++ b/test_manio.py
@@ -422,7 +422,7 @@ class TestYamlManifestIOIntegration:
         # Saving to non-writable folder must fail.
         assert manio.save_files("/proc", file_data) == RetVal(None, True)
 
-    def test_integration(self, tmp_path):
+    def test_load_save_ok(self, tmp_path):
         """Basic test that uses the {load,save} convenience functions."""
         # Create two YAML files, each with multiple manifests.
         dply = [mk_deploy(f"d_{_}") for _ in range(10)]

--- a/test_manio.py
+++ b/test_manio.py
@@ -17,37 +17,30 @@ def mk_deploy(name: str):
 
 
 class TestYamlManifestIO:
-    def test_integration(self):
-        # Setup test.
-        dply = [mk_deploy(f"d_{_}") for _ in range(10)]
-        meta = [square.make_meta(_) for _ in dply]
-        fdata_test_in = {
-            "m0.yaml": [(meta[0], dply[0]), (meta[1], dply[1])],
-            "foo/m1.yaml": [(meta[2], dply[2])],
-        }
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            pattern = os.path.join(tempdir, "**", "*.yaml")
-            assert glob.glob(pattern, recursive=True) == []
-            fnames_abs = {pjoin(tempdir, _) for _ in fdata_test_in.keys()}
-
-            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
-            assert manio.load(tempdir) == RetVal(fdata_test_in, False)
-
-            assert set(glob.glob(pattern, recursive=True)) == fnames_abs
-
     def test_manifest_lifecycle(self):
-        # Setup test.
+        """Load, sync and save manifests the hard way.
+
+        This test does not cover error scenarios. Instead, it shows how the
+        individual functions in `manio` play together.
+
+        This test does not load or save any files.
+
+        """
+        # Construct demo manifests in the same way as `load_files` would.
         dply = [mk_deploy(f"d_{_}") for _ in range(10)]
         meta = [square.make_meta(_) for _ in dply]
         fdata_test_in = {
-            "m0.yaml": yaml.safe_dump_all([dply[0], dply[1], dply[2]]),
-            "m1.yaml": yaml.safe_dump_all([dply[3], dply[4]]),
-            "m2.yaml": yaml.safe_dump_all([dply[5]]),
+            "m0.yaml": [dply[0], dply[1], dply[2]],
+            "m1.yaml": [dply[3], dply[4]],
+            "m2.yaml": [dply[5]],
+        }
+        fdata_test_in = {
+            k: yaml.safe_dump_all(v, default_flow_style=False)
+            for k, v in fdata_test_in.items()
         }
         expected_manifests = {meta[_]: dply[_] for _ in range(6)}
 
-        # ---------- LOAD YAML FILES ----------
+        # ---------- PARSE YAML FILES ----------
         # Parse Yaml string, extract MetaManifest and compile new dict from it.
         # :: Dict[Filename:YamlStr] -> Dict[Filename:List[(MetaManifest, YamlDict)]]
         fdata_meta, err = manio.parse(fdata_test_in)
@@ -62,32 +55,33 @@ class TestYamlManifestIO:
         assert local_manifests == expected_manifests
 
         # ---------- CREATE FAKE SERVER MANIFESTS ----------
-        # Create a fake set of server manifests from the `expected_manifests`.
+        # Create a fake set of server manifests based on `expected_manifests`.
         # In particular, pretend that K8s supplied two additional manifests,
         # lacks two others and features one with different content.
         server_manifests = expected_manifests
         del expected_manifests
 
-        server_manifests[meta[6]] = dply[6]
-        server_manifests[meta[7]] = dply[7]
-        del server_manifests[meta[3]], server_manifests[meta[5]]
-        server_manifests[meta[1]]["metadata"] = {"new": "label"}
+        server_manifests[meta[6]] = dply[6]  # add new one
+        server_manifests[meta[7]] = dply[7]  # add new one
+        del server_manifests[meta[3]], server_manifests[meta[5]]  # delete two
+        server_manifests[meta[1]]["metadata"] = {"new": "label"}  # modify one
 
         # ---------- SYNC SERVER MANIFESTS BACK TO LOCAL YAML FILES ----------
-        # Merge the server manifests into the correct local YAML file dict.
-        # * Upsert local with server values
-        # * Delete all local manifests not on the server
+        # Sync the local manifests to match those in the server.
+        # * Upsert local with server values.
+        # * Delete the manifests that do not exist on the server.
         # :: Dict[MetaManifests:YamlDict] -> Dict[Filename:List[(MetaManifest, YamlDict)]]
         updated_manifests, err = manio.sync(fdata_meta, server_manifests)
         assert err is False
 
-        # Strip the meta information
+        # Convert the data to YAML. The output would normally be passed to
+        # `save_files` but here we will verify it directly (see below).
         # :: Dict[Filename:List[(MetaManifest, YamlDict)]] -> Dict[Filename:YamlStr]
         fdata_raw_new, err = manio.unparse(updated_manifests)
         assert err is False
 
-        # Expected output after we merged back the changes (ie `dply[1]` is
-        # different, `dply[{3,5}]` were deleted and `dply[{6,7}]` are new).
+        # Expected output after we merged back the changes (reminder: `dply[1]`
+        # is different, `dply[{3,5}]` were deleted and `dply[{6,7}]` are new).
         # The new manifests must all end up in "default.yaml".
         expected = {
             "m0.yaml": [dply[0], server_manifests[meta[1]], dply[2]],
@@ -100,45 +94,55 @@ class TestYamlManifestIO:
         }
         assert fdata_raw_new == expected
 
-    def test_load_and_save_single_dir(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            fdata_test_in = {
-                "m0.yaml": "something 0",
-                "m1.yaml": "something 1",
-                "m2.yaml": "something 2",
-            }
-            fnames_rel = list(fdata_test_in.keys())
-            fnames_abs = [pjoin(tempdir, _) for _ in fnames_rel]
 
+class TestYamlManifestIOIntegration:
+    """These integration tests all write files to temporary folders."""
+
+    def test_integration(self):
+        """Save manifests then load them back."""
+        # Create two YAML files, each with multiple manifests.
+        dply = [mk_deploy(f"d_{_}") for _ in range(10)]
+        meta = [square.make_meta(_) for _ in dply]
+        fdata_test_in = {
+            "m0.yaml": [(meta[0], dply[0]), (meta[1], dply[1])],
+            "foo/m1.yaml": [(meta[2], dply[2])],
+        }
+        del dply, meta
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            # Save test file in temporary folder.
+            fnames_abs = {pjoin(tempdir, _) for _ in fdata_test_in.keys()}
+
+            # Save the test data, then load it back and verify.
+            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
+            assert manio.load(tempdir) == RetVal(fdata_test_in, False)
+
+            # Use `glob` to verify the files ended up in the correct location.
             pattern = os.path.join(tempdir, "**", "*.yaml")
-            assert glob.glob(pattern, recursive=True) == []
-            assert manio.save_files(tempdir, fdata_test_in) == RetVal(None, False)
-            assert set(glob.glob(pattern, recursive=True)) == set(fnames_abs)
+            assert set(glob.glob(pattern, recursive=True)) == fnames_abs
 
-            # Load files.
-            # :: List[Filename] -> Dict[Filename:YamlStr]
-            fdata_raw, err = manio.load_files(tempdir, fnames_rel)
-            assert err is False
-            assert fdata_raw == fdata_test_in
-
-    def test_load_and_save_sub_dir(self):
+    def test_load_and_save_file_single_dir(self):
+        """Use low level functions to save and load files."""
         with tempfile.TemporaryDirectory() as tempdir:
-            fdata_test_in = {
+            # Demo input for `save_files` below (content is irrelevant).
+            fdata = {
                 "m0.yaml": "something 0",
                 "foo/m1.yaml": "something 1",
                 "bar/m2.yaml": "something 2",
                 "foo/bar/blah/m2.yaml": "something 3",
             }
-            fnames_rel = list(fdata_test_in.keys())
+
+            # Convenience: extract absolute and relative file names.
+            fnames_rel = list(fdata.keys())
             fnames_abs = [pjoin(tempdir, _) for _ in fnames_rel]
 
+            # The target folder must be empty before we save the files.
             pattern = os.path.join(tempdir, "**", "*.yaml")
             assert glob.glob(pattern, recursive=True) == []
-            assert manio.save_files(tempdir, fdata_test_in) == RetVal(None, False)
+
+            # The target folder must now contain the expected files.
+            assert manio.save_files(tempdir, fdata) == RetVal(None, False)
             assert set(glob.glob(pattern, recursive=True)) == set(fnames_abs)
 
-            # Load files.
-            # :: List[Filename] -> Dict[Filename:YamlStr]
-            fdata_raw, err = manio.load_files(tempdir, fnames_rel)
-            assert err is False
-            assert fdata_raw == fdata_test_in
+            # Load the files from the temporary folder again.
+            assert manio.load_files(tempdir, fnames_rel) == RetVal(fdata, False)

--- a/test_manio.py
+++ b/test_manio.py
@@ -427,25 +427,24 @@ class TestYamlManifestIOIntegration:
         # Saving to non-writable folder must fail.
         assert manio.save_files("/proc", file_data) == RetVal(None, True)
 
-    def test_integration(self):
-        """Save manifests then load them back."""
+    def test_integration(self, tmp_path):
+        """Basic test that uses the {load,save} convenience functions."""
         # Create two YAML files, each with multiple manifests.
         dply = [mk_deploy(f"d_{_}") for _ in range(10)]
-        meta = [square.make_meta(_) for _ in dply]
+        meta = [square.make_meta(mk_deploy(f"d_{_}")) for _ in range(10)]
         fdata_test_in = {
             "m0.yaml": [(meta[0], dply[0]), (meta[1], dply[1])],
             "foo/m1.yaml": [(meta[2], dply[2])],
         }
         del dply, meta
 
-        with tempfile.TemporaryDirectory() as tempdir:
-            # Save test file in temporary folder.
-            fnames_abs = {pjoin(tempdir, _) for _ in fdata_test_in.keys()}
+        # Save test file in temporary folder.
+        fnames_abs = {pjoin(tmp_path, _) for _ in fdata_test_in.keys()}
 
-            # Save the test data, then load it back and verify.
-            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
-            assert manio.load(tempdir) == RetVal(fdata_test_in, False)
+        # Save the test data, then load it back and verify.
+        assert manio.save(tmp_path, fdata_test_in) == RetVal(None, False)
+        assert manio.load(tmp_path) == RetVal(fdata_test_in, False)
 
-            # Use `glob` to verify the files ended up in the correct location.
-            pattern = os.path.join(tempdir, "**", "*.yaml")
-            assert set(glob.glob(pattern, recursive=True)) == fnames_abs
+        # Use `glob` to verify the files ended up in the correct location.
+        pattern = os.path.join(tmp_path, "**", "*.yaml")
+        assert set(glob.glob(pattern, recursive=True)) == fnames_abs

--- a/test_manio.py
+++ b/test_manio.py
@@ -1,0 +1,118 @@
+import copy
+import tempfile
+
+import manio
+import square
+import test_square
+
+
+def mk_deploy(name: str):
+    return test_square.make_manifest("Deployment", name, "namespace")
+
+
+class TestYamlManifestIO:
+    def test_manifest_lifecycle(self):
+        # Setup test.
+        dply = [mk_deploy(f"d_{_}") for _ in range(10)]
+        meta = [square.make_meta(_) for _ in dply]
+        fdata_test_in = {
+            "m0.yaml": [dply[0], dply[1], dply[2]],
+            "m1.yaml": [dply[3], dply[4]],
+            "m2.yaml": [dply[5]],
+        }
+        expected_manifests = {meta[_]: dply[_] for _ in range(6)}
+
+        # ---------- LOAD YAML FILES ----------
+        # Parse Yaml string, extract MetaManifest and compile new dict from it.
+        # :: Dict[Filename:YamlStr] -> Dict[Filename:List[(MetaManifest, YamlDict)]]
+        fdata_meta, err = manio.parse(fdata_test_in)
+        assert err is False
+
+        # Drop the filenames and create a dict that uses MetaManifests as keys.
+        # :: Dict[Filename:List[(MetaManifest, YamlDict)]] -> Dict[MetaManifest:YamlDict]
+        local_manifests, err = manio.unpack(fdata_meta)
+        assert err is False
+
+        # Verify that the loaded manifests are correct.
+        assert local_manifests == expected_manifests
+
+        # ---------- CREATE FAKE SERVER MANIFESTS ----------
+        # Create a fake set of server manifests from the `expected_manifests`.
+        # In particular, pretend that K8s supplied two additional manifests,
+        # lacks two others and features one with different content.
+        server_manifests = expected_manifests
+        del expected_manifests
+
+        server_manifests[meta[6]] = dply[6]
+        server_manifests[meta[7]] = dply[7]
+        del server_manifests[meta[3]], server_manifests[meta[5]]
+        server_manifests[meta[1]]["metadata"] = {"new": "label"}
+
+        # ---------- SYNC SERVER MANIFESTS BACK TO LOCAL YAML FILES ----------
+        # Merge the server manifests into the local ones.
+        # * Upsert local with server values
+        # * Delete all local manifests not on the server
+        # :: Dict[MetaManifests:YamlDict] -> Dict[MetaManifest:YamlDict]
+        updated_manifests = manio.sync(local_manifests, server_manifests)
+
+        # Associate the manifests with the local filenames.
+        # :: Dict[MetaManifests:YamlDict] -> Dict[Filename:List[(MetaManifest, YamlDict)]]
+        fdata_meta_new = manio.pack(updated_manifests, fdata_meta)
+
+        # Strip the meta information
+        # :: Dict[Filename:List[(MetaManifest, YamlDict)]] -> Dict[Filename:YamlStr]
+        fdata_raw_new = manio.unparse(fdata_meta_new)
+
+        # Expected output after we merged back the changes (ie `dply[1]` is
+        # different, `dply[{3,5}]` were deleted and `dply[{6,7}]` are new).
+        # The new manifests must all end up in "default.yaml".
+        fdata_test_out = {
+            "m0.yaml": [dply[0], server_manifests[meta[1]], dply[2]],
+            "m1.yaml": [dply[4]],
+            "default.yaml": [dply[6], dply[7]],
+        }
+        assert fdata_raw_new == fdata_test_out
+
+    def test_load(self):
+        dply = [mk_deploy(f"d_{_}") for _ in range(10)]
+        fdata_test_in = {
+            "m0.yaml": [dply[0], dply[1], dply[2]],
+            "m1.yaml": [dply[3], dply[4]],
+            "m2.yaml": [dply[5]],
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            self.save_test_files(tempdir, fdata_test_in)
+
+            # Find the YAML files (does not actually load them) -> List[Str]
+            fnames, _ = manio.find(tempdir)
+
+            # Load files.
+            # :: List[Filename] -> Dict[Filename:YamlStr]
+            fdata_raw, _ = manio.load(fnames)
+            assert fdata_raw == fdata_test_in
+
+    def test_save(self):
+        dply = [mk_deploy(f"d_{_}") for _ in range(10)]
+        fdata_test_in = {
+            "m0.yaml": [dply[0], dply[1], dply[2]],
+            "m1.yaml": [dply[3], dply[4]],
+            "m2.yaml": [dply[5]],
+        }
+
+        # Save the files. Explicitly delete all those files whose YAML string
+        # is empty.
+        with tempfile.TemporaryDirectory() as tempdir:
+            manio.save(tempdir, fdata_test_in)
+
+            # Load back the results.
+            assert False
+
+            # Create a new file.
+            fdata_test_in["new.yaml"] = dply[6]
+            manio.save(tempdir, fdata_test_in)
+            assert False
+
+            # Delete one of the files.
+            del fdata_test_in["m0.yaml"]
+            manio.save(tempdir, fdata_test_in)
+            assert False

--- a/test_manio.py
+++ b/test_manio.py
@@ -89,12 +89,12 @@ class TestYamlManifestIO:
 
             pattern = os.path.join(tempdir, "**", "*.yaml")
             assert glob.glob(pattern, recursive=True) == []
-            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
+            assert manio.save_files(tempdir, fdata_test_in) == RetVal(None, False)
             assert set(glob.glob(pattern, recursive=True)) == set(fnames_abs)
 
             # Load files.
             # :: List[Filename] -> Dict[Filename:YamlStr]
-            fdata_raw, err = manio.load(tempdir, fnames_rel)
+            fdata_raw, err = manio.load_files(tempdir, fnames_rel)
             assert err is False
             assert fdata_raw == fdata_test_in
 
@@ -111,11 +111,11 @@ class TestYamlManifestIO:
 
             pattern = os.path.join(tempdir, "**", "*.yaml")
             assert glob.glob(pattern, recursive=True) == []
-            assert manio.save(tempdir, fdata_test_in) == RetVal(None, False)
+            assert manio.save_files(tempdir, fdata_test_in) == RetVal(None, False)
             assert set(glob.glob(pattern, recursive=True)) == set(fnames_abs)
 
             # Load files.
             # :: List[Filename] -> Dict[Filename:YamlStr]
-            fdata_raw, err = manio.load(tempdir, fnames_rel)
+            fdata_raw, err = manio.load_files(tempdir, fnames_rel)
             assert err is False
             assert fdata_raw == fdata_test_in

--- a/test_square.py
+++ b/test_square.py
@@ -73,20 +73,6 @@ class TestBasic:
         # assumptions about the location of the templates, tf, etc folder.
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-    @pytest.mark.xfail
-    def test_load_manifest_files(self):
-        """Recursively load all manifests in a given folder."""
-        assert False
-
-    @pytest.mark.xfail
-    def test_load_manifest_files_duplicate(self):
-        """Abort if the same resource is specified multiple times.
-
-        It does not matter if the duplicates occur in the same or different files.
-
-        """
-        assert False
-
     def test_find_namespace_orphans(self):
         """Return all resource manifests that belong to non-existing
         namespaces.

--- a/test_square.py
+++ b/test_square.py
@@ -26,8 +26,6 @@ def m_requests(request):
 
 
 def make_manifest(kind: str, name: str, namespace: str):
-    kind = kind.capitalize()
-
     manifest = {
         'apiVersion': 'v1',
         'kind': kind,


### PR DESCRIPTION
Supplies the functionality to read, write and intelligently patch local manifests.

All functions are implemented in `manio.py` (short for *Manifest IO*). The module has full unit test coverage.

`square.py` also uses those functions now but good test coverage is still elusive due to the PoC legacy.