### PR TITLE
Added tests for `square.main`.

### DIFF
--- a/square.py
+++ b/square.py
@@ -674,7 +674,11 @@ def main():
     elif param.parser == "patch":
         _, err = main_patch(config, client, manifest_folder, kinds, namespace)
     else:
-        print(f"Unknown command <{param.parser}>")
+        logit.error(f"Unknown command <{param.parser}>")
+        err = True
+
+    # Abort with non-zero exit code if there was an error.
+    if err:
         sys.exit(1)
 
 


### PR DESCRIPTION
Fixes #19.

Essentially, this PR just supplies tests. The only (minuscule) change is in `square.main`, which now returns with a non-zero exit code on error.