### PR TITLE
Binary build containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,28 +45,41 @@ jobs:
             # Run the pytest suite as an unprivileged user.
             sudo -u square pytest
 
-      - store_artifacts:
-          path: test-reports
-          destination: test-reports
-
-  binaries:
+  linux-binary:
     docker:
-      - image: python:3.7
-
-    # This will be </root/repo>.
+      - image: olitheolix/square:linux-latest
     working_directory: ~/repo
-
     steps:
       - checkout
-
       - run:
           name: install dependencies
           command: |
-            echo "Hello world"
+            pipenv install --system --deploy --dev
+            pyinstaller square.py --onefile
+
+      - store_artifacts:
+          path: dist
+          destination: binaries
+
+  windows-binary:
+    docker:
+      - image: olitheolix/square:windows-latest
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: install dependencies
+          command: |
+            wine pyinstaller --onefile --noupx square.py
+
+      - store_artifacts:
+          path: dist
+          destination: binaries
 
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build
-      - binaries
+      - linux-binary
+      - windows-binary

--- a/df-linux
+++ b/df-linux
@@ -2,59 +2,42 @@
 # this distro then the `square` binary will (probably) not work for you.
 FROM centos:7.2.1511
 
-RUN yum update -y
-RUN yum groupinstall -y "Development Tools"
-RUN yum install -y \
-    bzip2-devel \
-    db4-devel \
-    expat-devel \
-    gdbm-devel \
-    libffi-devel \
-    libpcap-devel \
-    ncurses-devel \
-    openssl-devel \
-    readline-devel \
-    sqlite-devel \
-    tk-devel \
-    wget \
-    xz-devel \
-    zlib-devel
-
 # Build Python 3.7.2 from source.
 ARG PYTHONVERSION=3.7.2
-RUN mkdir /src \
+
+RUN yum install -y \
+     bzip2-devel \
+     db4-devel \
+     expat-devel \
+     gdbm-devel \
+     libffi-devel \
+     libpcap-devel \
+     ncurses-devel \
+     openssl-devel \
+     readline-devel \
+     sqlite-devel \
+     tk-devel \
+     wget \
+     which \
+     xz-devel \
+     zlib-devel \
+  && yum groupinstall -y "Development Tools" \
+  && mkdir /src \
   && cd /src \
   && wget https://www.python.org/ftp/python/$PYTHONVERSION/Python-$PYTHONVERSION.tgz \
   && tar -xzvf Python-$PYTHONVERSION.tgz \
   && cd Python-$PYTHONVERSION \
   && ./configure --enable-shared \
-  && make -j8 \
-  && make install
+  && make -j2 \
+  && make install \
+  && rm -rf Python-$PYTHONVERSION \
+  && rm /etc/yum/protected.d/systemd.conf \
+  && yum history undo 4 -y \
+  && yum clean all \
+  && rm -rf /var/cache/yum
 
 # Add shared Python libraries to linker path.
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-# Install Python packages for "square".
-RUN pip3 install \
-  colorama \
-  flake8 \
-  flake8-isort \
-  google \
-  google-api-python-client \
-  ipython \
-  isort \
-  jsonpatch \
-  pyinstaller \
-  pytest \
-  pytest-cov \
-  pyyaml==4.2b4 \
-  requests \
-  requests-mock
-
-# Create dedicated project folder.
-ARG HOME=/home/square
-RUN mkdir $HOME
-ADD . $HOME
-
-# Build the Linux binary.
-RUN cd $HOME && pyinstaller square.py --onefile
+# Utility packages for Python.
+RUN pip3 install pipenv pyinstaller

--- a/df-windows
+++ b/df-windows
@@ -15,11 +15,3 @@ RUN wine pip install \
   pyyaml==4.2b4 \
   requests \
   requests-mock
-
-# Create dedicated project folder.
-ARG HOME=/home/square
-RUN mkdir $HOME
-ADD . $HOME
-
-# Build the Windows binary.
-RUN cd $HOME && wine pyinstaller --onefile --noupx square.py


### PR DESCRIPTION
CircleCI will now build Windows and Linux binaries.

Dockerhub will build and publish the base images that create the binaries. The images
are called `olitheolix/square:windows-latest` and `olitheolix/square:linux-latest`.

The binaries are not yet being published anywhere because I have not figured out how to do that with CircleCI.