### PR TITLE
43 Improve manifest stripping

### DIFF
--- a/dtypes.py
+++ b/dtypes.py
@@ -13,3 +13,5 @@ JsonPatch = collections.namedtuple('Patch', 'url ops')
 Manifests = collections.namedtuple('Manifests', 'local server files')
 MetaManifest = collections.namedtuple('MetaManifest', 'apiVersion kind namespace name')
 RetVal = collections.namedtuple('RetVal', 'data err')
+
+RESOURCE_SCHEMA = {}

--- a/manio.py
+++ b/manio.py
@@ -416,7 +416,7 @@ def save(folder, manifests: dict):
     return save_files(folder, fdata_raw)
 
 
-def metaspec(manifest: dict):
+def essential(manifest: dict):
     """Return a copy of `manifest` with only the salient keys.
 
     The salient keys are: `apiVersion`, `kind`, `metadata` and `spec`.
@@ -505,8 +505,8 @@ def diff(local: dict, server: dict):
     """
     # Clean up the input manifests because we do not want to diff the eg
     # `status` fields.
-    srv, err1 = metaspec(server)
-    loc, err2 = metaspec(local)
+    srv, err1 = essential(server)
+    loc, err2 = essential(local)
     if err1 or err2:
         return RetVal(None, True)
 

--- a/manio.py
+++ b/manio.py
@@ -608,8 +608,15 @@ def strip(config, manifest):
     # Create preliminary output manifest.
     stripped = {"apiVersion": version, "kind": kind}
 
-    # Convenience: this is the schema for the current resource.
-    schema = schemas.RESOURCE_SCHEMA[config.version][manifest["kind"]]
+    # Verify the schema for the current resource and K8s version exist.
+    try:
+        schema = schemas.RESOURCE_SCHEMA[config.version][manifest["kind"]]
+    except KeyError:
+        logit.error(
+            f"Unknown K8s version (<{config.version}>) "
+            "or resource kind: <{kind}>"
+        )
+        return RetVal(None, True)
 
     # Strip down the manifest to its essential parts and return it.
     try:

--- a/manio.py
+++ b/manio.py
@@ -617,4 +617,4 @@ def strip(config, manifest):
     except KeyError:
         return RetVal(None, True)
     else:
-        return RetVal(stripped, False)
+        return RetVal(dotdict.make(stripped), False)

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,52 @@
+"""Define the structure of the stripped manifest schema.
+
+A stripped manifest is a sub-set of a normal manifest. The remaining keys
+capture the salient information about the resource.
+
+For instance, almost all manifest can have a "status" field. Albeit useful for
+diagnostics, it makes no sense to compute diffs of "status" fields and submit
+them in patches.
+
+# Schema Conventions
+Schemas are normal dictionaries without a depth limit.  All keys correspond to
+a K8s manifest key. All value must be either dicts themselves, a bool to
+specify whether the fields must be included in the stripped manifest, or None
+if the field is not mandatory but should be included.
+
+* True: field will be included. It is an error if the input manifest lacks it.
+* False: field will not be included. It is an error if the input manifest has it.
+* None: field will be included if the input manifest has it, and ignored otherwise.
+
+"""
+schema_1_9 = {
+    "Deployment": {
+        "metadata": {
+            "labels": None,
+            "name": True,
+            "namespace": True,
+        },
+        "spec": True,
+    },
+    "Namespace": {
+        "metadata": {
+            "labels": None,
+            "name": True,
+            "namespace": False
+        },
+        "spec": True,
+    },
+    "Service": {
+        "metadata": {
+            "labels": None,
+            "name": True,
+            "namespace": True,
+        },
+        "spec": True,
+    },
+}
+
+
+RESOURCE_SCHEMA = {
+    "1.9": schema_1_9,
+    "1.10": schema_1_9,
+}

--- a/square.py
+++ b/square.py
@@ -147,8 +147,8 @@ def make_patch(config, local: dict, server: dict):
     """
     # Reduce local and server manifests to salient fields (ie apiVersion, kind,
     # metadata and spec). Abort on error.
-    local, err1 = manio.essential(local)
-    server, err2 = manio.essential(server)
+    local, err1 = manio.strip(config, local)
+    server, err2 = manio.strip(config, server)
     if err1 or err2:
         return RetVal(None, True)
 
@@ -224,7 +224,7 @@ def download_manifests(config, client, kinds, namespace):
             assert not err
 
             # Drop all manifest fields except "apiVersion", "metadata" and "spec".
-            ret = {k: manio.essential(man) for k, man in manifests.items()}
+            ret = {k: manio.strip(config, man) for k, man in manifests.items()}
             manifests = {k: v.data for k, v in ret.items()}
             err = any((v.err for v in ret.values()))
             assert not err
@@ -344,7 +344,7 @@ def compile_plan(config, local_manifests, server_manifests):
         srv = server_manifests[delta]
 
         # Compute textual diff (only useful for the user to study the diff).
-        diff_str, err = manio.diff(loc, srv)
+        diff_str, err = manio.diff(config, loc, srv)
         if err:
             return RetVal(None, True)
 

--- a/square.py
+++ b/square.py
@@ -147,8 +147,8 @@ def make_patch(config, local: dict, server: dict):
     """
     # Reduce local and server manifests to salient fields (ie apiVersion, kind,
     # metadata and spec). Abort on error.
-    local, err1 = manio.metaspec(local)
-    server, err2 = manio.metaspec(server)
+    local, err1 = manio.essential(local)
+    server, err2 = manio.essential(server)
     if err1 or err2:
         return RetVal(None, True)
 
@@ -224,7 +224,7 @@ def download_manifests(config, client, kinds, namespace):
             assert not err
 
             # Drop all manifest fields except "apiVersion", "metadata" and "spec".
-            ret = {k: manio.metaspec(man) for k, man in manifests.items()}
+            ret = {k: manio.essential(man) for k, man in manifests.items()}
             manifests = {k: v.data for k, v in ret.items()}
             err = any((v.err for v in ret.values()))
             assert not err

--- a/square.py
+++ b/square.py
@@ -171,7 +171,7 @@ def make_patch(config, local: dict, server: dict):
         return RetVal(None, True)
 
     # Determine the PATCH URL for the resource.
-    namespace = server.metadata.get("namespace", None)
+    namespace = server.metadata.namespace if server.kind != "Namespace" else None
     url, err = urlpath(config, server.kind, namespace)
     if err:
         return RetVal(None, True)

--- a/test_manio.py
+++ b/test_manio.py
@@ -704,6 +704,22 @@ class TestManifestValidation:
             valid = {"apiVersion": "v1", "kind": "TEST"}
             assert manio.strip(config, valid) == RetVal(None, True)
 
+    def test_strip_invalid_version_kind(self):
+        """Must abort gracefully for unknown K8s version or resource kind."""
+        # Minimal valid schema.
+        schema = {"1.10": {"TEST": {"metadata": None}}}
+
+        with mock.patch("manio.schemas.RESOURCE_SCHEMA", schema):
+            # Valid version but unknown resource.
+            config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+            manifest = {"apiVersion": "v1", "kind": "Unknown"}
+            assert manio.strip(config, manifest) == RetVal(None, True)
+
+            # Invalid version but known resource.
+            config = k8s.Config("url", "token", "ca_cert", "client_cert", "unknown")
+            manifest = {"apiVersion": "v1", "kind": "TEST"}
+            assert manio.strip(config, manifest) == RetVal(None, True)
+
     def test_strip_namespace(self):
         """Validate NAMESPACE manifests."""
         config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")

--- a/test_manio.py
+++ b/test_manio.py
@@ -1,4 +1,3 @@
-import pytest
 import k8s
 import random
 import unittest.mock as mock
@@ -839,118 +838,6 @@ class TestManifestValidation:
         }
         assert manio.strip(config, invalid) == RetVal(None, True)
 
-    def test_essential_basic_valid(self):
-        """Ensure it returns only the salient fields of valid manifests."""
-
-        # Minimal Deployment manifest with just the salient fields. Test
-        # function must return a deepcopy of it.
-        valid_deployment_manifest = {
-            'apiVersion': 'v1',
-            'kind': 'Deployment',
-            'metadata': {'name': 'foo', 'namespace': 'bar'},
-            'spec': {'some': 'thing'},
-        }
-        ret = manio.essential(valid_deployment_manifest)
-        assert ret == RetVal(valid_deployment_manifest, False)
-        assert valid_deployment_manifest is not ret.data
-
-        # Minimal Namespace manifest with just the salient fields. Test
-        # function must return a deepcopy of it.
-        valid_namespace_manifest = {
-            'apiVersion': 'v1',
-            'kind': 'Namespace',
-            'metadata': {'name': 'foo'},
-            'spec': {'some': 'thing'},
-        }
-        ret = manio.essential(valid_namespace_manifest)
-        assert ret == RetVal(valid_namespace_manifest, False)
-        assert valid_namespace_manifest is not ret.data
-
-        # Function must accept additional entries (eg "additional" in example
-        # below) but not return them. It must not matter whether those
-        # additional entries are actually valid keys in the manifest.
-        valid_namespace_manifest_add = {
-            'apiVersion': 'v1',
-            'kind': 'Namespace',
-            'metadata': {'name': 'foo', 'additional': 'entry'},
-            'spec': {'some': 'thing'},
-            'status': {"some": "status"},
-            'additional': 'entry',
-        }
-        ret = manio.essential(valid_namespace_manifest_add)
-        assert ret == RetVal(valid_namespace_manifest, False)
-
-    def test_essential_automanifests(self):
-        """Verify that it works with the `make_manifest` test function.
-
-        This test merely validates that the output of the `make_manifest`
-        function used in various tests produces valid manifests as far as
-        `essential` is concerned.
-
-        """
-        # Create a valid manifest for each supported resource kind and verify
-        # that the test function accepts it.
-        for kind in square.SUPPORTED_KINDS:
-            if kind == "Namespace":
-                manifest = make_manifest(kind, None, "name")
-            else:
-                manifest = make_manifest(kind, "ns", "name")
-
-            ret = manio.essential(manifest)
-            assert ret.err is False and len(ret.data) > 0
-
-        # Invalid Namespace manifest: metadata.namespace field is not None.
-        manifest = make_manifest("Namespace", "ns", "name")
-        assert manio.essential(manifest) == RetVal(None, True)
-
-        # Unknown resource kind "foo".
-        manifest = make_manifest("foo", "ns", "name")
-        assert manio.essential(manifest) == RetVal(None, True)
-
-    def test_essential_missing_fields(self):
-        """Incomplete manifests must be rejected."""
-        # A valid deployment manifest.
-        valid = {
-            "apiVersion": "v1",
-            "kind": "Deployment",
-            "metadata": {"name": "foo", "namespace": "bar"},
-            "spec": {"some": "thing"},
-        }
-
-        # Create stunted manifests by creating a copy of `valid` that misses
-        # one key in each iteration. The test function must reject all those
-        # manifests and return an error.
-        for field in valid:
-            invalid = {k: v for k, v in valid.items() if k != field}
-            assert manio.essential(invalid) == RetVal(None, True)
-
-        # Metadata for Namespace manifests must contain a "name" field.
-        invalid = {
-            "apiVersion": "v1",
-            "kind": "Namespace",
-            "metadata": {"foo": "bar"},
-            "spec": {"some": "thing"},
-        }
-        assert manio.essential(invalid) == RetVal(None, True)
-
-        # Metadata for Namespace manifests must not contain a "namespace" field.
-        invalid = {
-            "apiVersion": "v1",
-            "kind": "Namespace",
-            "metadata": {"namespace": "namespace"},
-            "spec": {"some": "thing"},
-        }
-        assert manio.essential(invalid) == RetVal(None, True)
-
-        # Metadata for non-namespace manifests must contain "name" and "namespace".
-        invalid = {
-            "apiVersion": "v1",
-            "kind": "Deployment",
-            "metadata": {"name": "name"},
-            "spec": {"some": "thing"},
-        }
-        assert manio.essential(invalid) == RetVal(None, True)
-
 
 class TestDiff:
     @classmethod
@@ -959,6 +846,9 @@ class TestDiff:
 
     def test_diff_ok(self):
         """Diff two valid manifests and (roughly) verify the output."""
+        # Dummy config for (only "version" is relevant).
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+
         # Two valid manifests.
         srv = make_manifest("Deployment", "namespace", "name1")
         loc = make_manifest("Deployment", "namespace", "name2")
@@ -968,7 +858,7 @@ class TestDiff:
         loc = dotdict.make(loc)
 
         # Diff the manifests. Must not return an error.
-        diff_str, err = manio.diff(loc, srv)
+        diff_str, err = manio.diff(config, loc, srv)
         assert err is False
 
         # Since it is difficult to compare the correct diff string due to
@@ -979,6 +869,9 @@ class TestDiff:
 
     def test_diff_err(self):
         """Diff two valid manifests and verify the output."""
+        # Dummy config for (only "version" is relevant).
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+
         # Create two valid manifests, then stunt one in such a way that
         # `essential` will reject it.
         valid = make_manifest("Deployment", "namespace", "name1")
@@ -987,9 +880,9 @@ class TestDiff:
 
         # Test function must return with an error, irrespective of which
         # manifest was invalid.
-        assert manio.diff(valid, invalid) == RetVal(None, True)
-        assert manio.diff(invalid, valid) == RetVal(None, True)
-        assert manio.diff(invalid, invalid) == RetVal(None, True)
+        assert manio.diff(config, valid, invalid) == RetVal(None, True)
+        assert manio.diff(config, invalid, valid) == RetVal(None, True)
+        assert manio.diff(config, invalid, invalid) == RetVal(None, True)
 
 
 class TestYamlManifestIOIntegration:

--- a/test_manio.py
+++ b/test_manio.py
@@ -527,7 +527,7 @@ class TestManifestValidation:
     def setup_class(cls):
         square.setup_logging(9)
 
-    def test_metaspec_basic_valid(self):
+    def test_essential_basic_valid(self):
         """Ensure it returns only the salient fields of valid manifests."""
 
         # Minimal Deployment manifest with just the salient fields. Test
@@ -538,7 +538,7 @@ class TestManifestValidation:
             'metadata': {'name': 'foo', 'namespace': 'bar'},
             'spec': {'some': 'thing'},
         }
-        ret = manio.metaspec(valid_deployment_manifest)
+        ret = manio.essential(valid_deployment_manifest)
         assert ret == RetVal(valid_deployment_manifest, False)
         assert valid_deployment_manifest is not ret.data
 
@@ -550,7 +550,7 @@ class TestManifestValidation:
             'metadata': {'name': 'foo'},
             'spec': {'some': 'thing'},
         }
-        ret = manio.metaspec(valid_namespace_manifest)
+        ret = manio.essential(valid_namespace_manifest)
         assert ret == RetVal(valid_namespace_manifest, False)
         assert valid_namespace_manifest is not ret.data
 
@@ -565,15 +565,15 @@ class TestManifestValidation:
             'status': {"some": "status"},
             'additional': 'entry',
         }
-        ret = manio.metaspec(valid_namespace_manifest_add)
+        ret = manio.essential(valid_namespace_manifest_add)
         assert ret == RetVal(valid_namespace_manifest, False)
 
-    def test_metaspec_automanifests(self):
+    def test_essential_automanifests(self):
         """Verify that it works with the `make_manifest` test function.
 
         This test merely validates that the output of the `make_manifest`
         function used in various tests produces valid manifests as far as
-        `metaspec` is concerned.
+        `essential` is concerned.
 
         """
         # Create a valid manifest for each supported resource kind and verify
@@ -584,18 +584,18 @@ class TestManifestValidation:
             else:
                 manifest = make_manifest(kind, "ns", "name")
 
-            ret = manio.metaspec(manifest)
+            ret = manio.essential(manifest)
             assert ret.err is False and len(ret.data) > 0
 
         # Invalid Namespace manifest: metadata.namespace field is not None.
         manifest = make_manifest("Namespace", "ns", "name")
-        assert manio.metaspec(manifest) == RetVal(None, True)
+        assert manio.essential(manifest) == RetVal(None, True)
 
         # Unknown resource kind "foo".
         manifest = make_manifest("foo", "ns", "name")
-        assert manio.metaspec(manifest) == RetVal(None, True)
+        assert manio.essential(manifest) == RetVal(None, True)
 
-    def test_metaspec_missing_fields(self):
+    def test_essential_missing_fields(self):
         """Incomplete manifests must be rejected."""
         # A valid deployment manifest.
         valid = {
@@ -610,7 +610,7 @@ class TestManifestValidation:
         # manifests and return an error.
         for field in valid:
             invalid = {k: v for k, v in valid.items() if k != field}
-            assert manio.metaspec(invalid) == RetVal(None, True)
+            assert manio.essential(invalid) == RetVal(None, True)
 
         # Metadata for Namespace manifests must contain a "name" field.
         invalid = {
@@ -619,7 +619,7 @@ class TestManifestValidation:
             "metadata": {"foo": "bar"},
             "spec": {"some": "thing"},
         }
-        assert manio.metaspec(invalid) == RetVal(None, True)
+        assert manio.essential(invalid) == RetVal(None, True)
 
         # Metadata for Namespace manifests must not contain a "namespace" field.
         invalid = {
@@ -628,7 +628,7 @@ class TestManifestValidation:
             "metadata": {"namespace": "namespace"},
             "spec": {"some": "thing"},
         }
-        assert manio.metaspec(invalid) == RetVal(None, True)
+        assert manio.essential(invalid) == RetVal(None, True)
 
         # Metadata for non-namespace manifests must contain "name" and "namespace".
         invalid = {
@@ -637,7 +637,7 @@ class TestManifestValidation:
             "metadata": {"name": "name"},
             "spec": {"some": "thing"},
         }
-        assert manio.metaspec(invalid) == RetVal(None, True)
+        assert manio.essential(invalid) == RetVal(None, True)
 
 
 class TestDiff:
@@ -668,7 +668,7 @@ class TestDiff:
     def test_diff_err(self):
         """Diff two valid manifests and verify the output."""
         # Create two valid manifests, then stunt one in such a way that
-        # `metaspec` will reject it.
+        # `essential` will reject it.
         valid = make_manifest("Deployment", "namespace", "name1")
         invalid = make_manifest("Deployment", "namespace", "name2")
         del invalid["kind"]

--- a/test_manio.py
+++ b/test_manio.py
@@ -666,6 +666,17 @@ class TestManifestValidation:
             expected = {"apiVersion": "", "kind": "TEST"}
             assert manio.strip(config, manifest) == RetVal(expected, False)
 
+    def test_strip_invalid_schema(self):
+        """Create a corrupt schema and verify we get a proper error message."""
+        version = "1.10"
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", version)
+        schema = {version: {"TEST": {"invalid": "foo"}}}
+
+        with mock.patch("manio.schemas.RESOURCE_SCHEMA", schema):
+            # Valid manifest with purely mandatory fields.
+            valid = {"apiVersion": "v1", "kind": "TEST"}
+            assert manio.strip(config, valid) == RetVal(None, True)
+
     def test_strip_namespace(self):
         """Validate NAMESPACE manifests."""
         config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")

--- a/test_manio.py
+++ b/test_manio.py
@@ -596,7 +596,9 @@ class TestManifestValidation:
                 "metadata": {"name": "name"},
                 "spec": "spec",
             }
-            assert manio.strip(config, valid) == RetVal(valid, False)
+            ret = manio.strip(config, valid)
+            assert ret == RetVal(valid, False)
+            assert isinstance(ret.data, dotdict.DotDict)
             del valid
 
             # Valid manifest with all mandatory and *some* optional keys (

--- a/test_square.py
+++ b/test_square.py
@@ -291,7 +291,7 @@ class TestDownloadManifests:
         # The expected outcome is a Dict[MetaManifest:dict] of all the items in
         # DeploymentList and NamespaceList.
         expected = {
-            manio.make_meta(_): manio.metaspec(_).data
+            manio.make_meta(_): manio.essential(_).data
             for _ in meta
         }
 
@@ -472,13 +472,13 @@ class TestPlan:
         invalid_cfg = k8s.Config("url", "token", "cert", "client_cert", "invalid")
 
         # Create two valid manifests, then stunt one in such a way that
-        # `metaspec` will reject it.
+        # `manio.essential` will reject it.
         kind, namespace, name = "Deployment", "namespace", "name"
         valid = make_manifest(kind, namespace, name)
         invalid = make_manifest(kind, namespace, name)
         del invalid["kind"]
 
-        # Must handle errors from `metaspec`.
+        # Must handle errors from `manio.essential`.
         assert square.make_patch(valid_cfg, valid, invalid) == RetVal(None, True)
         assert square.make_patch(valid_cfg, invalid, valid) == RetVal(None, True)
         assert square.make_patch(valid_cfg, invalid, invalid) == RetVal(None, True)

--- a/test_square.py
+++ b/test_square.py
@@ -425,6 +425,20 @@ class TestPatchK8s:
         ret = square.make_patch(config, loc, srv)
         assert ret.err is False and len(ret.data) > 0
 
+    @mock.patch.object(square, "urlpath")
+    def test_make_patch_error_urlpath(self, m_url):
+        """Coverage gap: simulate `urlpath` error."""
+        # Setup.
+        kind, ns, name = "Deployment", "ns", "foo"
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+
+        # Simulate `urlpath` error.
+        m_url.return_value = RetVal(None, True)
+
+        # Test function must return with error.
+        loc = srv = make_manifest(kind, ns, name)
+        assert square.make_patch(config, loc, srv) == RetVal(None, True)
+
 
 class TestPlan:
     @classmethod

--- a/test_square.py
+++ b/test_square.py
@@ -395,7 +395,8 @@ class TestPatchK8s:
         """`Namespace` specific corner cases.
 
         Namespaces are special because, by definition, they must not contain a
-        `metadata.Namespace` attribute.
+        `metadata.Namespace` attribute. This will trigger a subtly different
+        code path in `make_patch`.
 
         """
         config = types.SimpleNamespace(url='http://examples.com/', version="1.10")

--- a/test_square.py
+++ b/test_square.py
@@ -291,7 +291,7 @@ class TestDownloadManifests:
         # The expected outcome is a Dict[MetaManifest:dict] of all the items in
         # DeploymentList and NamespaceList.
         expected = {
-            manio.make_meta(_): manio.essential(_).data
+            manio.make_meta(_): manio.strip(config, _).data
             for _ in meta
         }
 
@@ -369,7 +369,7 @@ class TestPatchK8s:
         config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
 
         # Demo manifest.
-        srv = make_manifest('Deployment', 'namespace', 'name')
+        srv = make_manifest('Deployment', 'Namespace', 'name')
 
         # `apiVersion` must match.
         loc = copy.deepcopy(srv)
@@ -660,7 +660,7 @@ class TestPlan:
         # output structure below.
         patch, err = square.make_patch(config, loc_man[meta], srv_man[meta])
         assert not err
-        diff_str, err = manio.diff(loc_man[meta], srv_man[meta])
+        diff_str, err = manio.diff(config, loc_man[meta], srv_man[meta])
         assert not err
 
         # Verify the test function returns the correct Patch and diff.

--- a/test_square.py
+++ b/test_square.py
@@ -487,13 +487,13 @@ class TestPlan:
         invalid_cfg = k8s.Config("url", "token", "cert", "client_cert", "invalid")
 
         # Create two valid manifests, then stunt one in such a way that
-        # `manio.essential` will reject it.
+        # `manio.strip` will reject it.
         kind, namespace, name = "Deployment", "namespace", "name"
         valid = make_manifest(kind, namespace, name)
         invalid = make_manifest(kind, namespace, name)
         del invalid["kind"]
 
-        # Must handle errors from `manio.essential`.
+        # Must handle errors from `manio.strip`.
         assert square.make_patch(valid_cfg, valid, invalid) == RetVal(None, True)
         assert square.make_patch(valid_cfg, invalid, valid) == RetVal(None, True)
         assert square.make_patch(valid_cfg, invalid, invalid) == RetVal(None, True)


### PR DESCRIPTION
Implements #43 

This PR replaces `manio.metaspec` with a new `manio.strip` function. Outwardly, this function does the same. Internally, it uses easy to write schemas (in new `schemas.py`) to specify which keys should and should not be included.

This should make it now easy to support more resource types (see #44).