### PR TITLE
56 minikube context

### DIFF
--- a/k8s.py
+++ b/k8s.py
@@ -65,6 +65,7 @@ def load_incluster_config(
 
 def load_gke_config(
         kubeconfig: Filepath,
+        context: Optional[str],
         disable_warnings: bool = False) -> Optional[Config]:
     """Return K8s access config for GKE cluster described in `kubeconfig`.
 
@@ -73,6 +74,11 @@ def load_gke_config(
     Inputs:
         kubconfig: str
             Name of kubeconfig file.
+        context: str
+            Kubeconf context. Use `None` to use default context.
+        disable_warnings: bool
+            Whether or not do disable GCloud warnings.
+
     Returns:
         Config
 

--- a/k8s.py
+++ b/k8s.py
@@ -128,7 +128,20 @@ def load_minikube_config(
         fname: Filepath,
         context: Optional[str],
 ) -> Optional[Config]:
+    """Load minikube configuration from `fname`.
 
+    Return None on error.
+
+    Inputs:
+        kubconfig: str
+            Path to kubeconfig file, eg "~/.kube/config.yaml"
+        context: str
+            Kubeconf context. Use `None` to use default context.
+
+    Returns:
+        Config
+
+    """
     # Load `kubeconfig`.
     try:
         kubeconf = yaml.load(open(fname))
@@ -177,7 +190,8 @@ def load_minikube_config(
 
 
 def load_auto_config(
-        kubeconfig: str,
+        fname: Filepath,
+        context: Optional[str],
         disable_warnings: bool = False) -> Optional[Config]:
     """Automagically find and load the correct K8s configuration.
 
@@ -188,8 +202,13 @@ def load_auto_config(
     2) `load_gke_config`
 
     Inputs:
-        kubconfig: str
-            Name of kubeconfig file.
+        fname: str
+            Path to kubeconfig file, eg "~/.kube/config.yaml"
+            Use `None` to find out automatically or for incluster credentials.
+
+        context: str
+            Kubeconf context. Use `None` to use default context.
+
     Returns:
         Config
 
@@ -197,15 +216,19 @@ def load_auto_config(
     conf = load_incluster_config()
     if conf is not None:
         return conf
+    logit.debug("Incluster config failed")
 
-    conf = load_minikube_config(kubeconfig)
+    conf = load_minikube_config(fname, context)
     if conf is not None:
         return conf
+    logit.debug("Minikube config failed")
 
-    conf = load_gke_config(kubeconfig, disable_warnings)
+    conf = load_gke_config(fname, context, disable_warnings)
     if conf is not None:
         return conf
+    logit.debug("GKE config failed")
 
+    logit.error(f"Could not find a valid configuration in <{fname}>")
     return None
 
 

--- a/square.py
+++ b/square.py
@@ -56,7 +56,7 @@ def parse_commandline_args():
     parent.add_argument(
         "-v", "--verbosity", action="count", default=0,
         help="Specify multiple times to increase log level."
-             " -v: WARNING -vv: INFO -vvv: DEBUG."
+             " -v: WARNING -vv: INFO -vvv: DEBUG"
     )
     parent.add_argument(
         "-n", type=str, nargs="*",
@@ -69,7 +69,11 @@ def parse_commandline_args():
     )
     parent.add_argument(
         "--kubeconfig", type=str, metavar="path", default="~/.kube/config",
-        help="Location of kubeconfig file (default='~/kube/config').",
+        help="Location of kubeconfig file (default='~/kube/config')",
+    )
+    parent.add_argument(
+        "--context", type=str, metavar="ctx", dest="ctx", default=None,
+        help="Kubernetes context",
     )
 
     # The primary parser for the top level options (eg GET, PATCH, ...).
@@ -632,6 +636,7 @@ def main_get(
 
 def main() -> int:
     param = parse_commandline_args()
+    print(param)
 
     # Initialise logging.
     setup_logging(param.verbosity)
@@ -640,7 +645,7 @@ def main() -> int:
     # K8s API.
     kubeconfig = os.path.expanduser(param.kubeconfig)
     try:
-        config = k8s.load_auto_config(kubeconfig, disable_warnings=True)
+        config = k8s.load_auto_config(kubeconfig, param.ctx, disable_warnings=True)
         assert config
 
         client = k8s.session(config)

--- a/square.py
+++ b/square.py
@@ -636,7 +636,6 @@ def main_get(
 
 def main() -> int:
     param = parse_commandline_args()
-    print(param)
 
     # Initialise logging.
     setup_logging(param.verbosity)

--- a/support/kubeconf.yaml
+++ b/support/kubeconf.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: encrypted-authority-data
+    server: https://1.2.3.4
+  name: gke_foo-bar-123456_australia-southeast1-foobar
+- cluster:
+    certificate-authority: ca.crt
+    server: https://192.168.0.177:8443
+  name: minikube
+contexts:
+- context:
+    cluster: gke_foo-bar-123456_australia-southeast1-foobar
+    user: gke_foo-bar-123456_australia-southeast1-foobar
+  name: gke
+- context:
+    cluster: minikube
+    user: minikube
+  name: minikube
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: gke_foo-bar-123456_australia-southeast1-foobar
+  user:
+    auth-provider:
+      config:
+        access-token: encrypted-access-token
+        cmd-args: config config-helper --format=json
+        cmd-path: /usr/bin/gcloud
+        expiry: 2019-01-14T02:48:51Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+- name: minikube
+  user:
+    client-certificate: client.crt
+    client-key: client.key

--- a/test_square.py
+++ b/test_square.py
@@ -893,7 +893,7 @@ class TestMain:
 
         # Pretend all main functions return errors.
         m_cmd.return_value = types.SimpleNamespace(
-            verbosity=0, parser="invalid", kubeconfig="conf"
+            verbosity=0, parser="invalid", kubeconfig="conf", ctx="ctx",
         )
         assert square.main() == 1
 


### PR DESCRIPTION
Add `--context` command line argument.

`k8s.load_minikube_config` is now context aware.

Fixes #56.