### PR TITLE
Bugfix: empty dicts returned by "download" and "load" are valid.

### DIFF
--- a/square.py
+++ b/square.py
@@ -485,8 +485,8 @@ def main_patch(
     """
     try:
         # Load manifests from local files.
-        local_meta, local_files, err = manio.load(folder)
-        assert not err and local_meta and local_files
+        local_meta, _, err = manio.load(folder)
+        assert not err and local_meta is not None
 
         # Download manifests from K8s.
         server, err = manio.download(config, client, kinds, namespaces)
@@ -558,12 +558,12 @@ def main_diff(
     """
     try:
         # Load manifests from local files.
-        local_meta, local_files, err = manio.load(folder)
-        assert not err and local_meta and local_files
+        local_meta, _, err = manio.load(folder)
+        assert not err and local_meta is not None
 
         # Download manifests from K8s.
         server, err = manio.download(config, client, kinds, namespaces)
-        assert not err and server
+        assert not err and server is not None
 
         # Prune the manifests to only include manifests for the specified
         # resources and namespaces. The pruning is not technically necessary
@@ -606,12 +606,12 @@ def main_get(
     """
     try:
         # Load manifests from local files.
-        local_meta, local_files, err = manio.load(folder)
-        assert not err and local_meta and local_files
+        _, local_files, err = manio.load(folder)
+        assert not err and local_files is not None
 
         # Download manifests from K8s.
         server, err = manio.download(config, client, kinds, namespaces)
-        assert not err and server
+        assert not err and server is not None
 
         # Prune the manifests to only include manifests for the specified
         # resources and namespaces. This is not technically necessary
@@ -665,12 +665,11 @@ def main() -> int:
         _, err = main_patch(config, client, param.folder, param.kinds, param.namespaces)
     else:
         logit.error(f"Unknown command <{param.parser}>")
-        err = True
-
-    # Abort with non-zero exit code if there was an error.
-    if err:
         return 1
 
+    # Return error code.
+    if err:
+        return 1
     return 0
 
 

--- a/test_square.py
+++ b/test_square.py
@@ -649,8 +649,8 @@ class TestMainOptions:
         )
 
         # Pretend that all K8s requests succeed.
-        m_down.return_value = ("srv", False)
-        m_load.return_value = ("foo", "bar", False)
+        m_down.return_value = ({}, False)
+        m_load.return_value = ({}, {}, False)
         m_prun.side_effect = ["local", "server"]
         m_plan.return_value = (plan, False)
         m_post.return_value = (None, False)
@@ -717,8 +717,8 @@ class TestMainOptions:
         plan = DeploymentPlan(create=[], patch=[], delete=[])
 
         # All auxiliary functions will succeed.
-        m_load.return_value = ("foo", "bar", False)
-        m_down.return_value = ("server-dl", False)
+        m_load.return_value = ({}, {}, False)
+        m_down.return_value = ({}, False)
         m_prune.side_effect = ["local", "server"]
         m_plan.return_value = (plan, False)
 
@@ -758,8 +758,10 @@ class TestMainOptions:
 
         """
         # Simulate successful responses from the two auxiliary functions.
-        m_load.return_value = ("foo", "files", False)
-        m_down.return_value = ("server-dl", False)
+        # The `load` function must return empty dicts to ensure the error
+        # conditions are properly coded.
+        m_load.return_value = ({}, {}, False)
+        m_down.return_value = ({}, False)
         m_prun.return_value = "server"
         m_sync.return_value = ("synced", False)
         m_save.return_value = (None, False)
@@ -771,8 +773,8 @@ class TestMainOptions:
         assert square.main_get(*args) == (None, False)
         m_load.assert_called_once_with("folder")
         m_down.assert_called_once_with("config", "client", "kinds", "ns")
-        m_prun.assert_called_once_with("server-dl", "kinds", "ns")
-        m_sync.assert_called_once_with("files", "server", "kinds", "ns")
+        m_prun.assert_called_once_with({}, "kinds", "ns")
+        m_sync.assert_called_once_with({}, "server", "kinds", "ns")
         m_save.assert_called_once_with("folder", "synced")
 
         # Simulate an error with `manio.save`.


### PR DESCRIPTION
Fixes #58 

The bug was caused by a sloppily coded error check that mistakenly triggered for empty dicts when, in fact, it should only have triggered for `None`.