### PR TITLE
Support env vars in exec section of kubeconfig file.

### DIFF
--- a/support/kubeconf.yaml
+++ b/support/kubeconf.yaml
@@ -49,7 +49,11 @@ users:
       - -i
       - eks-cluster-name
       command: aws-iam-authenticator
-      env: null
+      env:
+        - name: foo1
+          value: bar1
+        - name: foo2
+          value: bar2
 - name: minikube
   user:
     client-certificate: client.crt


### PR DESCRIPTION
Set the environment variables from the kubeconfig file to get the bearer token.

Previously, these environment variables were ignored which may have lead to errors with eg. the `aws-iam-authenticator`. This PR remedies that.

NOTE: the code that parses the `exec` section of the kubeconfig file is still more of a hack than
a clean implementation. It works for me based on my own kubeconfig files, not based on an official spec for that section of the kubeconfig file.