### PR TITLE
Match Ingress scheme to Nginx layout.

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -71,6 +71,10 @@ schema_1_9 = {
     },
     "Ingress": {
         "metadata": {
+            "annotations": {
+                "ingress.kubernetes.io/configuration-snippet": None,
+                "kubernetes.io/ingress.class": None,
+            },
             "labels": None,
             "name": True,
             "namespace": True,


### PR DESCRIPTION
This is somewhat of a hack because the Ingress scheme is now custom made for Nginx ingresses.
However, this is the best solution I can think of at the moment until I have more flexible manifest schemas.