### PR TITLE
Add "-l" option to filter by label.

### DIFF
--- a/test_helpers.py
+++ b/test_helpers.py
@@ -1,14 +1,15 @@
 from typing import Any, Dict
 
 
-def make_manifest(kind: str, namespace: str, name: str) -> dict:
+def make_manifest(kind: str, namespace: str, name: str,
+                  labels: Dict[str, str] = {}) -> dict:
     manifest: Dict[str, Any]
     manifest = {
         'apiVersion': 'v1',
         'kind': kind,
         'metadata': {
             'name': name,
-            'labels': {'key': 'val'},
+            'labels': labels,
             'foo': 'bar',
         },
         'spec': {


### PR DESCRIPTION
Add `-l` option to filter by (one or more) labels.

This makes it possible to run `square` selectively not only by resource name and namespace, but also the resource labels. It mimcks the syntax of `kubectl`.