### PR TITLE
Confirm patch

### DIFF
--- a/dtypes.py
+++ b/dtypes.py
@@ -53,7 +53,7 @@ assert set(SUPPORTED_KINDS) == set(RESOURCE_ALIASES.keys())
 
 SUPPORTED_VERSIONS = ("1.9", "1.10", "1.11", "1.13", "1.14")
 
-Config = namedtuple('Config', 'url token ca_cert client_cert version')
+Config = namedtuple('Config', 'url token ca_cert client_cert version name')
 DeltaCreate = namedtuple("DeltaCreate", "meta url manifest")
 DeltaDelete = namedtuple("DeltaDelete", "meta url manifest")
 DeltaPatch = namedtuple("Delta", "meta diff patch")

--- a/k8s.py
+++ b/k8s.py
@@ -74,16 +74,19 @@ def load_kubeconfig(
             logit.error(f"Could not find information for context <{ctx}>")
             return (None, None, None)
 
-        # Unpack the cluster and user information.
-        cluster_info = cluster_info[0]["cluster"]
+        # Unpack the cluster- and user information.
+        cluster_name = cluster_info[0]["name"]
+        cluster_info_out = cluster_info[0]["cluster"]
+        cluster_info_out["name"] = cluster_name
         user_info = user_info[0]["user"]
+        del cluster_info
     except KeyError:
         logit.error(f"Kubeconfig YAML file <{fname}> is invalid")
         return (None, None, None)
 
     # Success. The explicit `dicts()` are to satisfy MyPy.
     logit.info(f"Loaded {ctx} from Kubeconfig file <{fname}>")
-    return (username, dict(user_info), dict(cluster_info))
+    return (username, dict(user_info), dict(cluster_info_out))
 
 
 def load_incluster_config(
@@ -124,6 +127,7 @@ def load_incluster_config(
         ca_cert=str(fname_cert),
         client_cert=None,
         version=None,
+        name="",
     )
 
 
@@ -184,6 +188,7 @@ def load_gke_config(
         ca_cert=ssl_ca_cert,
         client_cert=None,
         version=None,
+        name=cluster["name"],
     )
 
 
@@ -263,6 +268,7 @@ def load_eks_config(
         ca_cert=ssl_ca_cert,
         client_cert=None,
         version=None,
+        name=cluster["name"],
     )
 
 
@@ -305,6 +311,7 @@ def load_minikube_config(
             ca_cert=cluster["certificate-authority"],
             client_cert=client_cert,
             version=None,
+            name=cluster["name"],
         )
     except KeyError:
         logit.debug(f"Context {context} in <{fname}> is not a Minikube config")

--- a/square.py
+++ b/square.py
@@ -550,6 +550,17 @@ def prune(
     return out
 
 
+def user_confirmed() -> bool:
+    """Return True iff the user answers with `yes`."""
+    print(f"Apply the changes?")
+    print('Only "yes" will commence the rollout')
+
+    try:
+        return input("  Your answer: ") == "yes"
+    except KeyboardInterrupt:
+        return False
+
+
 def main_patch(
         config: Config,
         client,
@@ -596,8 +607,13 @@ def main_patch(
         plan, err = compile_plan(config, local, server)
         assert not err and plan is not None
 
-        # Present the plan confirm to go ahead with the user.
+        # Present the plan to the user.
         print_deltas(plan)
+
+        # Ask for user confirmation. Abort if the user does not give it.
+        if not user_confirmed():
+            logit.error("User abort")
+            return (None, True)
 
         # Create the missing resources.
         for data in plan.create:

--- a/square.py
+++ b/square.py
@@ -68,9 +68,8 @@ def parse_commandline_args():
         """Return Kubeconfig file or raise an error."""
         # Return `kubeconf` unless it has the default value which denotes an
         # impossible file name.
-        if kubeconf is not None:
-            if kubeconf != "--unknown--":
-                return kubeconf
+        if kubeconf != "--unknown--":
+            return kubeconf
 
         # Return the environment variable, or raise an error if it does not exist.
         try:

--- a/square.py
+++ b/square.py
@@ -550,14 +550,16 @@ def prune(
     return out
 
 
-def user_confirmed() -> bool:
-    """Return True iff the user answers with `yes`."""
+def user_confirmed(answer: str = "yes") -> bool:
+    """Return True iff the user answers with `answer`."""
+    assert answer, "BUG: desired answer must be non-empty string"
     print(f"Apply the changes?")
-    print('Only "yes" will commence the rollout')
+    print(f'Only "{answer}" will commence the rollout.')
 
     try:
-        return input("  Your answer: ") == "yes"
+        return input("  Your answer: ") == answer
     except KeyboardInterrupt:
+        print()
         return False
 
 
@@ -611,7 +613,7 @@ def main_patch(
         print_deltas(plan)
 
         # Ask for user confirmation. Abort if the user does not give it.
-        if not user_confirmed():
+        if not user_confirmed(config.name):
             logit.error("User abort")
             return (None, True)
 

--- a/support/kubeconf.yaml
+++ b/support/kubeconf.yaml
@@ -3,26 +3,26 @@ clusters:
 - cluster:
     certificate-authority-data: Y2EuY2VydAo= # Base64 encoded "ca.crt"
     server: https://1.2.3.4
-  name: gke_foo-bar-123456_australia-southeast1-foobar
+  name: clustername-gke
 - cluster:
     certificate-authority: ca.crt
     server: https://192.168.0.177:8443
-  name: minikube
+  name: clustername-minikube
 - cluster:
     certificate-authority-data: Y2EuY2VydAo= # Base64 encoded "ca.crt"
     server: https://5.6.7.8
-  name: eks
+  name: clustername-eks
 contexts:
 - context:
-    cluster: eks
+    cluster: clustername-eks
     user: aws
   name: eks
 - context:
-    cluster: gke_foo-bar-123456_australia-southeast1-foobar
+    cluster: clustername-gke
     user: gke_foo-bar-123456_australia-southeast1-foobar
   name: gke
 - context:
-    cluster: minikube
+    cluster: clustername-minikube
     user: minikube
   name: minikube
 current-context: minikube

--- a/test_k8s.py
+++ b/test_k8s.py
@@ -387,7 +387,7 @@ class TestK8sKubeconfig:
             ca_cert="ca.crt",
             client_cert=k8s.ClientCert(crt="client.crt", key="client.key"),
             version=None,
-            name="minikube",
+            name="clustername-minikube",
         )
 
         # Function must also accept pathlib.Path instances.
@@ -426,7 +426,7 @@ class TestK8sKubeconfig:
             ca_cert="ca.cert",
             client_cert=None,
             version=None,
-            name="gke_foo-bar-123456_australia-southeast1-foobar",
+            name="clustername-gke",
         )
 
         # GKE is not the default context in the demo kubeconf file, which means
@@ -462,7 +462,7 @@ class TestK8sKubeconfig:
             ca_cert="ca.cert",
             client_cert=None,
             version=None,
-            name="eks",
+            name="clustername-eks",
         )
 
         # Verify that the correct external command was called, including

--- a/test_manio.py
+++ b/test_manio.py
@@ -451,7 +451,7 @@ class TestManifestValidation:
 
         """
         version = "1.10"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", version)
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", version, "")
         schema = {
             "invalid": False,
             "metadata": {
@@ -539,7 +539,7 @@ class TestManifestValidation:
 
         """
         version = "1.10"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", version)
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", version, "")
         schema = {
             "metadata": {
                 "name": None,
@@ -572,7 +572,7 @@ class TestManifestValidation:
     def test_strip_invalid_schema(self):
         """Create a corrupt schema and verify we get a proper error message."""
         version = "1.10"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", version)
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", version, "")
         schema = {version: {"TEST": {"invalid": "foo"}}}
 
         with mock.patch("manio.schemas.RESOURCE_SCHEMA", schema):
@@ -587,18 +587,18 @@ class TestManifestValidation:
 
         with mock.patch("manio.schemas.RESOURCE_SCHEMA", schema):
             # Valid version but unknown resource.
-            config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+            config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
             manifest = {"apiVersion": "v1", "kind": "Unknown"}
             assert manio.strip(config, manifest) == (None, True)
 
             # Invalid version but known resource.
-            config = k8s.Config("url", "token", "ca_cert", "client_cert", "unknown")
+            config = k8s.Config("url", "token", "ca_cert", "client_cert", "unknown", "")
             manifest = {"apiVersion": "v1", "kind": "TEST"}
             assert manio.strip(config, manifest) == (None, True)
 
     def test_strip_namespace(self):
         """Validate NAMESPACE manifests."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid namespace manifest with a few optional and irrelevant keys.
         valid = {
@@ -629,7 +629,7 @@ class TestManifestValidation:
 
     def test_strip_service(self):
         """Validate SERVICE manifests."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid service manifest with a few optional and irrelevant keys.
         valid = {
@@ -689,7 +689,7 @@ class TestManifestValidation:
 
     def test_strip_deployment(self):
         """Validate DEPLOYMENT manifests."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid service manifest with a few optional and irrelevant keys.
         valid = {
@@ -740,7 +740,7 @@ class TestDiff:
     def test_diff_ok(self):
         """Diff two valid manifests and (roughly) verify the output."""
         # Dummy config for (only "version" is relevant).
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Two valid manifests.
         srv = make_manifest("Deployment", "namespace", "name1")
@@ -763,7 +763,7 @@ class TestDiff:
     def test_diff_err(self):
         """Diff two valid manifests and verify the output."""
         # Dummy config for (only "version" is relevant).
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Create two valid manifests, then stunt one in such a way that
         # `essential` will reject it.
@@ -1281,7 +1281,7 @@ class TestDownloadManifests:
         actually execute.
 
         """
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
         meta = [
             make_manifest("Namespace", None, "ns0"),
             make_manifest("Namespace", None, "ns1"),
@@ -1397,7 +1397,7 @@ class TestDownloadManifests:
     @mock.patch.object(k8s, 'get')
     def test_download_err(self, m_get):
         """Simulate a download error."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid NamespaceList with one element.
         man_list_ns = {

--- a/test_square.py
+++ b/test_square.py
@@ -265,7 +265,7 @@ class TestPatchK8s:
         """Basic test: compute patch between two identical resources."""
         # Setup.
         kind, ns, name = 'Deployment', 'ns', 'foo'
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # PATCH URLs require the resource name at the end of the request path.
         url = urlpath(config, kind, ns)[0] + f'/{name}'
@@ -285,7 +285,7 @@ class TestPatchK8s:
 
         """
         # Setup.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Demo manifest.
         srv = make_manifest('Deployment', 'Namespace', 'name')
@@ -352,7 +352,7 @@ class TestPatchK8s:
         """Coverage gap: simulate `urlpath` error."""
         # Setup.
         kind, ns, name = "Deployment", "ns", "foo"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Simulate `urlpath` error.
         m_url.return_value = (None, True)
@@ -376,7 +376,7 @@ class TestPlan:
         label and one to add the new ones.
 
         """
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Two valid manifests.
         kind, namespace, name = "Deployment", "namespace", "name"
@@ -405,8 +405,8 @@ class TestPlan:
 
     def test_make_patch_err(self):
         """Verify error cases with invalid or incompatible manifests."""
-        valid_cfg = k8s.Config("url", "token", "cert", "client_cert", "1.10")
-        invalid_cfg = k8s.Config("url", "token", "cert", "client_cert", "invalid")
+        valid_cfg = k8s.Config("url", "token", "cert", "client_cert", "1.10", "")
+        invalid_cfg = k8s.Config("url", "token", "cert", "client_cert", "invalid", "")
 
         # Create two valid manifests, then stunt one in such a way that
         # `manio.strip` will reject it.
@@ -438,7 +438,7 @@ class TestPlan:
 
         """
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Allocate arrays for the MetaManifests and resource URLs.
         meta = [None] * 5
@@ -503,7 +503,7 @@ class TestPlan:
     def test_compile_plan_create_delete_err(self, m_part):
         """Simulate `urlpath` errors"""
         # Invalid configuration. We will use it to trigger an error in `urlpath`.
-        cfg_invalid = k8s.Config("url", "token", "cert", "cert", "invalid")
+        cfg_invalid = k8s.Config("url", "token", "cert", "cert", "invalid", "")
 
         # Valid ManifestMeta and dummy manifest dict.
         meta = manio.make_meta(make_manifest("Deployment", "ns", "name"))
@@ -534,7 +534,7 @@ class TestPlan:
 
         """
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Allocate arrays for the MetaManifests.
         meta = [None] * 4
@@ -581,7 +581,7 @@ class TestPlan:
 
         """
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Define a single resource.
         meta = MetaManifest('v1', 'Namespace', None, 'ns1')
@@ -614,7 +614,7 @@ class TestPlan:
     def test_compile_plan_err(self, m_patch, m_diff, m_part):
         """Use mocks for the internal function calls to simulate errors."""
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Define a single resource and valid dummy return value for
         # `square.partition_manifests`.
@@ -663,7 +663,7 @@ class TestMainOptions:
         test because it shares virtually all the boiler plate code.
         """
         # Valid client config and MetaManifest.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
         meta = manio.make_meta(make_manifest("Deployment", "ns", "name"))
 
         # Valid Patch.
@@ -871,7 +871,7 @@ class TestMain:
 
         """
         # Dummy configuration.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Mock all calls to the K8s API.
         m_k8s.load_auto_config.return_value = config
@@ -929,7 +929,7 @@ class TestMain:
 
         """
         # Dummy configuration.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Mock all calls to the K8s API.
         m_k8s.load_auto_config.return_value = config
@@ -956,7 +956,7 @@ class TestMain:
 
         """
         # Dummy configuration.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10")
+        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Mock all calls to the K8s API.
         m_k8s.load_auto_config.return_value = config

--- a/test_square.py
+++ b/test_square.py
@@ -731,35 +731,35 @@ class TestMainOptions:
         # Make `delete` fail.
         m_prun.side_effect = ["local", "server"]
         m_delete.return_value = (None, True)
-        with mock.patch.object(square, 'input', lambda _: cname):
+        with mock.patch.object(square, 'input'):
             assert square.main_patch(*args) == (None, True)
 
         # Make `patch` fail.
         m_prun.side_effect = ["local", "server"]
         m_patch.return_value = (None, True)
-        with mock.patch.object(square, 'input', lambda _: cname):
+        with mock.patch.object(square, 'input'):
             assert square.main_patch(*args) == (None, True)
 
         # Make `post` fail.
         m_prun.side_effect = ["local", "server"]
         m_post.return_value = (None, True)
-        with mock.patch.object(square, 'input', lambda _: cname):
+        with mock.patch.object(square, 'input'):
             assert square.main_patch(*args) == (None, True)
 
         # Make `compile_plan` fail.
         m_prun.side_effect = ["local", "server"]
         m_plan.return_value = (None, True)
-        with mock.patch.object(square, 'input', lambda _: cname):
+        with mock.patch.object(square, 'input'):
             assert square.main_patch(*args) == (None, True)
 
         # Make `download_manifests` fail.
         m_down.return_value = (None, True)
-        with mock.patch.object(square, 'input', lambda _: cname):
+        with mock.patch.object(square, 'input'):
             assert square.main_patch(*args) == (None, True)
 
         # Make `load` fail.
         m_load.return_value = (None, None, True)
-        with mock.patch.object(square, 'input', lambda _: cname):
+        with mock.patch.object(square, 'input'):
             assert square.main_patch(*args) == (None, True)
 
     @mock.patch.object(manio, "load")
@@ -1075,3 +1075,8 @@ class TestMain:
         for answer in answers:
             with mock.patch.object(square, 'input', lambda _: answer):
                 assert square.user_confirmed("yes") is False
+
+        # Must gracefully handle keyboard interrupts and return False.
+        with mock.patch.object(square, 'input') as m_input:
+            m_input.side_effect = KeyboardInterrupt
+            assert square.user_confirmed("yes") is False


### PR DESCRIPTION
User must now type the cluster name before `square` will apply the patches.