### PR TITLE
Parser now copes with superfluous "---" separators.

### DIFF
--- a/manio.py
+++ b/manio.py
@@ -107,7 +107,7 @@ def parse(file_yaml: Dict[Filepath, str]) -> Tuple[Optional[LocalManifestLists],
             return (None, True)
 
         # Convert List[manifest] into List[(MetaManifest, manifest)].
-        out[fname] = [(make_meta(_), _) for _ in manifests]
+        out[fname] = [(make_meta(_), _) for _ in manifests if _ is not None]
 
     # Drop all files without manifests.
     out = {k: v for k, v in out.items() if len(v) > 0}

--- a/test_manio.py
+++ b/test_manio.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import random
 import unittest.mock as mock
@@ -162,6 +163,18 @@ class TestYamlManifestIO:
             "m2.yaml": [(meta[2], dply[2])],
         }
         assert manio.parse(fdata_test_in) == (expected, False)
+
+        # Add a superfluous "---" at the beginning/end of the document. This
+        # mast not throw the parser and it must not include it in the output as
+        # an empty document.
+        fdata_test_blank_pre = copy.deepcopy(fdata_test_in)
+        fdata_test_blank_post = copy.deepcopy(fdata_test_in)
+        fdata_test_blank_post["m2.yaml"] = fdata_test_blank_pre["m2.yaml"] + "\n---\n"
+        fdata_test_blank_pre["m2.yaml"] = "\n---\n" + fdata_test_blank_pre["m2.yaml"]
+        out, err = manio.parse(fdata_test_blank_post)
+        assert not err and len(out["m2.yaml"]) == len(expected["m2.yaml"])
+        out, err = manio.parse(fdata_test_blank_pre)
+        assert not err and len(out["m2.yaml"]) == len(expected["m2.yaml"])
 
     def test_parse_err(self):
         """Intercept YAML decoding errors."""


### PR DESCRIPTION
* Ignore the empty documents that results from superflous `---` separators at the end of YAML files.