### PR TITLE
Minor cleanup in schemas.

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -59,6 +59,7 @@ schema_1_9 = {
             "name": True,
             "namespace": True,
         },
+        "creationTimestamp": False,
         "spec": True,
     },
     "HorizontalPodAutoscaler": {
@@ -136,8 +137,7 @@ schema_1_9 = {
         "spec": {
             "ports": None,
             "selector": None,
-            "sessionAffinity": True,
-            "type": None,
+            "type": True,
         },
     },
     "ServiceAccount": {

--- a/test_manio.py
+++ b/test_manio.py
@@ -674,7 +674,6 @@ class TestManifestValidation:
             "spec": {
                 "ports": "optional",
                 "selector": "optional",
-                "sessionAffinity": "mandatory",
                 "type": "optional",
             },
         }


### PR DESCRIPTION
* Ignore `CreationTimestamp` of deployments.
* Make `Service.type` mandatory.
* Remove `Service.sessionAffinity`