### PR TITLE
Better defaults

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 KUBECONFIG=/does/not/exist
+SQUARE_FOLDER=manifests/

--- a/square.py
+++ b/square.py
@@ -80,26 +80,26 @@ def parse_commandline_args():
     parent.add_argument(
         "-n", type=str, nargs="*",
         metavar="ns", dest="namespaces",
-        help="List of namespaces (omit to operate in all namespaces)",
+        help="List of namespaces (omit to consider all)",
     )
     parent.add_argument(
         "-l", type=_validate_label, nargs="*",
         metavar="labels", dest="labels", default=tuple(),
-        help="Only consider resources with these labels",
+        help="List of K8s resources to consider or just 'all'",
     )
     parent.add_argument(
         "--kubeconfig", type=str, metavar="path",
         default=os.environ.get("KUBECONFIG", None),
-        help="Location of kubeconfig file (defaults to KUBECONFIG env var)",
+        help="Location of kubeconfig file (defaults to env KUBECONFIG)",
     )
     parent.add_argument(
         "--folder", type=str, metavar="path",
         default=os.environ.get("SQUARE_FOLDER", "./"),
-        help="Manifest folder (defaults to SQUARE_FOLDER env var)",
+        help="Manifest folder (defaults to env SQUARE_FOLDER)",
     )
     parent.add_argument(
         "--context", type=str, metavar="ctx", dest="ctx", default=None,
-        help="Kubernetes context",
+        help="Kubernetes context (use default one if unspecified)",
     )
 
     # The primary parser for the top level options (eg GET, PATCH, ...).

--- a/test_square.py
+++ b/test_square.py
@@ -1074,6 +1074,32 @@ class TestMain:
                 with pytest.raises(SystemExit):
                     square.parse_commandline_args()
 
+    def test_parse_commandline_args_folder(self):
+        """Use the correct manifest folder."""
+        # Backup environment variables and set a custom SQUARE_FOLDER value.
+        new_env = os.environ.copy()
+
+        # Populate the environment with a SQUARE_FOLDER.
+        new_env["SQUARE_FOLDER"] = "envvar"
+        with mock.patch.dict("os.environ", values=new_env, clear=True):
+            # Square must use the supplied value and ignore the environment variable.
+            with mock.patch("sys.argv", ["square.py", "get", "svc", "--folder", "/tmp"]):
+                ret = square.parse_commandline_args()
+                assert ret.folder == "/tmp"
+
+            # Square must fall back to SQUARE_FOLDER if it exists.
+            with mock.patch("sys.argv", ["square.py", "get", "svc"]):
+                ret = square.parse_commandline_args()
+                assert ret.folder == "envvar"
+
+        # Square must default to "./" in the absence of "--folder" and SQUARE_FOLDER.
+        # parameters and environment variable.
+        del new_env["SQUARE_FOLDER"]
+        with mock.patch.dict("os.environ", values=new_env, clear=True):
+            with mock.patch("sys.argv", ["square.py", "get", "svc"]):
+                ret = square.parse_commandline_args()
+                assert ret.folder == "./"
+
     def test_user_confirmed(self):
         # "yes" must return True.
         with mock.patch.object(square, 'input', lambda _: "yes"):


### PR DESCRIPTION
* Simplify parsing of `--kubeconfig` argument
* Manifest folder now defaults to `./`