### PR TITLE
Introduce explicit selectors

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,6 +1,6 @@
 import pathlib
 from collections import namedtuple
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
 # We support these resource types. The order matters because it determines the
 # order in which the manifests will be grouped in the output files.
@@ -66,3 +66,10 @@ Filepath = Union[str, pathlib.PurePath]
 LocalManifests = Dict[Filepath, Tuple[MetaManifest, dict]]
 LocalManifestLists = Dict[Filepath, List[Tuple[MetaManifest, dict]]]
 ServerManifests = Dict[MetaManifest, dict]
+
+
+class Selectors(NamedTuple):
+    """Comprises all the filters to select manifests."""
+    kinds: Iterable[str]
+    namespaces: Optional[Iterable[str]]
+    labels: Optional[Iterable[Tuple[str, str]]]

--- a/square/manio.py
+++ b/square/manio.py
@@ -158,15 +158,15 @@ def unpack(manifests: LocalManifestLists) -> Tuple[Optional[ServerManifests], bo
 
     # Find out if all meta manifests were unique. If not, log the culprits and
     # return with an error.
-    is_unique = True
+    unique = True
     for meta, fnames in all_meta.items():
         if len(fnames) > 1:
-            is_unique = False
+            unique = False
             logit.error(
                 f"Meta manifest {meta} was defined {len(fnames)} times: "
                 f"{str.join(', ', fnames)}"
             )
-    if not is_unique:
+    if not unique:
         return (None, True)
 
     # Compile the input manifests into a new dict with the meta manifest as key.

--- a/square/square.py
+++ b/square/square.py
@@ -558,8 +558,8 @@ def prune(
     else:
         out3 = {k: v for k, v in out2.items() if k.namespace in namespaces}
 
-    # Ignore the default token because K8s creates that one automatically in
-    # each namespace and touching it is usually a bad idea.
+    # Ignore the "default-token-*" Secrets that K8s creates automatically since
+    # it is usually a bad good idea to touch them at all.
     out = {
         k: v for k, v in out3.items()
         if not (k.kind == "Secret" and k.name.startswith("default-token-"))
@@ -602,6 +602,8 @@ def main_apply(
             Resource types to fetch, eg ["Deployment", "Namespace"]
         namespaces: Iterable
             Only use those namespaces. Set to `None` to use all.
+        labels: Iterable
+            Only use manifests with those labels.
 
     Returns:
         None
@@ -684,6 +686,8 @@ def main_plan(
             Resource types to fetch, eg ["Deployment", "Namespace"]
         namespaces: Iterable
             Only use those namespaces. Set to `None` to use all.
+        labels: Iterable
+            Only use manifests with those labels.
 
     Returns:
         None
@@ -735,6 +739,8 @@ def main_get(
             Resource types to fetch, eg ["Deployment", "Namespace"]
         namespaces: Iterable
             Only use those namespaces. Set to `None` to use all.
+        labels: Iterable
+            Only use manifests with those labels.
 
     Returns:
         None
@@ -780,8 +786,8 @@ def main() -> int:
     # Initialise logging.
     setup_logging(param.verbosity)
 
-    # Create a `requests` client with proper security certificates to access
-    # K8s API.
+    # Create a `requests` client with proper security certificates to access the
+    # Kubernetes API.
     kubeconfig = os.path.expanduser(param.kubeconfig)
     try:
         config = k8s.load_auto_config(kubeconfig, param.ctx, disable_warnings=True)

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -704,8 +704,8 @@ class TestMainOptions:
             m_delete.return_value = (None, False)
 
         # The arguments to the test function will always be the same in this test.
-        args = config, "client", "folder", ["kinds"], ["ns"], (("foo", "bar"), ("x", "y"))
-        sel = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        selectors = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        args = config, "client", "folder", selectors
 
         # Square must never create/patch/delete anything if the user did not
         # answer "yes".
@@ -721,8 +721,8 @@ class TestMainOptions:
         reset_mocks()
         with mock.patch.object(square, 'input', lambda _: cname):
             assert square.main_apply(*args) == (None, False)
-        m_load.assert_called_once_with("folder", sel)
-        m_down.assert_called_once_with(config, "client", sel)
+        m_load.assert_called_once_with("folder", selectors)
+        m_down.assert_called_once_with(config, "client", selectors)
         m_plan.assert_called_once_with(config, "local", "server")
         m_post.assert_called_once_with("client", "create_url", "create_man")
         m_apply.assert_called_once_with("client", patch.url, patch.ops)
@@ -787,14 +787,14 @@ class TestMainOptions:
         m_plan.return_value = (plan, False)
 
         # The arguments to the test function will always be the same in this test.
-        args = "cfg", "client", "folder", ["kinds"], ["ns"], (("foo", "bar"), ("x", "y"))
-        sel = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        selectors = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        args = "config", "client", "folder", selectors
 
         # A successfull DIFF only computes and prints the plan.
         assert square.main_plan(*args) == (None, False)
-        m_load.assert_called_once_with("folder", sel)
-        m_down.assert_called_once_with("cfg", "client", sel)
-        m_plan.assert_called_once_with("cfg", "local", "server")
+        m_load.assert_called_once_with("folder", selectors)
+        m_down.assert_called_once_with("config", "client", selectors)
+        m_plan.assert_called_once_with("config", "local", "server")
 
         # Make `compile_plan` fail.
         m_prune.side_effect = ["local", "server"]
@@ -832,15 +832,15 @@ class TestMainOptions:
         m_save.return_value = (None, False)
 
         # The arguments to the test function will always be the same in this test.
-        args = "config", "client", "folder", "kinds", "ns", (("foo", "bar"), ("x", "y"))
-        sel = Selectors("kinds", "ns", (("foo", "bar"), ("x", "y")))
+        selectors = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        args = "config", "client", "folder", selectors
 
         # Call test function and verify it passed the correct arguments.
         assert square.main_get(*args) == (None, False)
-        m_load.assert_called_once_with("folder", sel)
-        m_down.assert_called_once_with("config", "client", sel)
-        m_prun.assert_called_once_with({}, sel)
-        m_sync.assert_called_once_with({}, "server", "kinds", "ns")
+        m_load.assert_called_once_with("folder", selectors)
+        m_down.assert_called_once_with("config", "client", selectors)
+        m_prun.assert_called_once_with({}, selectors)
+        m_sync.assert_called_once_with({}, "server", selectors)
         m_save.assert_called_once_with("folder", "synced")
 
         # Simulate an error with `manio.save`.
@@ -897,7 +897,8 @@ class TestMain:
             del args
 
         # Every main function must have been called exactly once.
-        args = config, "client", "myfolder", ["Deployment", "Service"], None, tuple()
+        selectors = Selectors(["Deployment", "Service"], None, tuple())
+        args = config, "client", "myfolder", selectors
         m_get.assert_called_once_with(*args)
         m_plan.assert_called_once_with(*args)
         m_apply.assert_called_once_with(*args)


### PR DESCRIPTION
Refactor only, no functional change.

This PR introduces the explicit `Selector` data type to simplify calling signatures and better group the related `kinds`, `namespaces` and `labels` that govern which manifests to process.