### PR TITLE
New selectors

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,6 +1,8 @@
 import pathlib
 from collections import namedtuple
-from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
+from typing import (
+    Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union,
+)
 
 # We support these resource types. The order matters because it determines the
 # order in which the manifests will be grouped in the output files.
@@ -72,4 +74,4 @@ class Selectors(NamedTuple):
     """Comprises all the filters to select manifests."""
     kinds: Iterable[str]
     namespaces: Optional[Iterable[str]]
-    labels: Optional[Iterable[Tuple[str, str]]]
+    labels: Optional[Set[Tuple[str, str]]]

--- a/square/manio.py
+++ b/square/manio.py
@@ -146,10 +146,13 @@ def unpack_list(manifest_list: dict,
     # all the manifests that do not match the `selectors`.
     manifests = {}
     for manifest in manifest_list["items"]:
+        # The "kind" key is missing from the manifest when K8s returns them in
+        # a list. Here we manually add it again because it is part of every
+        # properly formatted stand-alone manifest.
+        manifest = copy.deepcopy(manifest)
+        manifest["kind"] = kind
+        manifest['apiVersion'] = apiversion
         if select(manifest, selectors):
-            manifest = copy.deepcopy(manifest)
-            manifest['apiVersion'] = apiversion
-            manifest['kind'] = kind
             manifests[make_meta(manifest)] = manifest
     return (manifests, False)
 

--- a/square/manio.py
+++ b/square/manio.py
@@ -73,17 +73,20 @@ def select(manifest: dict, selectors: Selectors) -> bool:
         ns = manifest.get("metadata", {}).get("name", None)
     elif kind == "Secret":
         if name.startswith("default-token-"):
+            logit.debug("Skipping default token Secret")
             return False
     else:
         ns = manifest.get("metadata", {}).get("namespace", None)
 
     # Proceed only if the resource kind is among the desired ones.
     if kind not in selectors.kinds:
+        logit.debug(f"Kind {kind} does not match selector {selectors.kinds}")
         return False
 
     # Unless the namespace selector is None, the resource must match it.
     if selectors.namespaces is not None:
         if ns not in selectors.namespaces:
+            logit.debug(f"Namespace {ns} does not match selector {selectors.namespaces}")
             return False
 
     # Convert the labels dictionary into a set of (key, value) tuples. We can
@@ -94,6 +97,7 @@ def select(manifest: dict, selectors: Selectors) -> bool:
     # Unless the label selector is None, the resource must match it.
     if selectors.labels is not None:
         if not selectors.labels.issubset(labels):
+            logit.debug(f"Labels {labels} do not match selector {selectors.labels}")
             return False
 
     # If we get to here then the resource matches all selectors.
@@ -242,8 +246,8 @@ def unpack(manifests: LocalManifestLists) -> Tuple[Optional[ServerManifests], bo
         if len(fnames) > 1:
             unique = False
             logit.error(
-                f"Meta manifest {meta} was defined {len(fnames)} times: "
-                f"{str.join(', ', fnames)}"
+                f"Duplicate ({len(fnames)}x) manifest {meta}. "
+                f"Defined in {str.join(', ', fnames)}"
             )
     if not unique:
         return (None, True)

--- a/square/manio.py
+++ b/square/manio.py
@@ -142,12 +142,16 @@ def unpack_list(manifest_list: dict,
     return (manifests, False)
 
 
-def parse(file_yaml: Dict[Filepath, str]) -> Tuple[Optional[LocalManifestLists], bool]:
+def parse(
+        file_yaml: Dict[Filepath, str],
+        selectors: Selectors) -> Tuple[Optional[LocalManifestLists], bool]:
     """Parse all YAML strings in `file_yaml` and return result.
 
     Inputs:
         file_yaml: Dict[Filepath, str]
             Raw data as returned by `load_files`.
+        selectors: Selectors
+            Skip all manifests that do not match these `selectors`.
 
     Returns:
         LocalManifestLists: The YAML parsed manifests of each file.
@@ -305,7 +309,7 @@ def sync(
     Inputs:
         local_manifests: Dict[Filepath, Tuple[MetaManifest, dict]]
         server_manifests: Dict[MetaManifest, dict]
-        selectors: Selectors,
+        selectors: Selectors
             Only operate on resources that match the selectors.
 
     Returns:
@@ -671,7 +675,7 @@ def load(folder: Filepath, selectors: Selectors) -> Tuple[
         assert not err and fdata_raw is not None
 
         # Return the YAML parsed manifests.
-        man_files, err = parse(fdata_raw)
+        man_files, err = parse(fdata_raw, selectors)
         assert not err and man_files is not None
 
         # Remove the Filepath dimension.

--- a/square/manio.py
+++ b/square/manio.py
@@ -176,12 +176,19 @@ def parse(
             )
             return (None, True)
 
+        # Remove all empty manifests. This typically happens when the YAML
+        # file ends with a "---" string.
+        manifests = [_ for _ in manifests if _ is not None]
+
+        # Retain only those manifests that satisfy the selectors.
+        manifests = [_ for _ in manifests if select(_, selectors)]
+
         # Convert List[manifest] into List[(MetaManifest, manifest)].
         # Abort if `make_meta` throws a KeyError which happens if `file_yaml`
         # does not actually contain a Kubernetes manifest but some other
         # (valid) YAML.
         try:
-            out[fname] = [(make_meta(_), _) for _ in manifests if _ is not None]
+            out[fname] = [(make_meta(_), _) for _ in manifests]
         except KeyError:
             logit.error(f"{file_yaml} does not look like a K8s manifest file.")
             return None, True

--- a/square/manio.py
+++ b/square/manio.py
@@ -100,7 +100,8 @@ def select(manifest: dict, selectors: Selectors) -> bool:
     return True
 
 
-def unpack_list(manifest_list: dict) -> Tuple[Optional[ServerManifests], bool]:
+def unpack_list(manifest_list: dict,
+                selectors: Selectors) -> Tuple[Optional[ServerManifests], bool]:
     """Unpack a K8s List item, eg `DeploymentList` or `NamespaceList`.
 
     Return a dictionary where each key uniquely identifies the resource via a
@@ -109,6 +110,7 @@ def unpack_list(manifest_list: dict) -> Tuple[Optional[ServerManifests], bool]:
     Input:
         manifest_list: dict
             K8s response from GET request for eg `deployments`.
+        selectors: Selectors
 
     Returns:
         dict[MetaManifest:dict]
@@ -754,7 +756,7 @@ def download(
 
                 # Parse the K8s List (eg DeploymentList, NamespaceList, ...) into a
                 # Dict[MetaManifest, dict] dictionary.
-                manifests, err = unpack_list(manifest_list)
+                manifests, err = unpack_list(manifest_list, selectors)
                 assert not err and manifests is not None
 
                 # Drop all manifest fields except "apiVersion", "metadata" and "spec".

--- a/square/manio.py
+++ b/square/manio.py
@@ -145,7 +145,9 @@ def unpack_list(manifest_list: dict,
 def parse(
         file_yaml: Dict[Filepath, str],
         selectors: Selectors) -> Tuple[Optional[LocalManifestLists], bool]:
-    """Parse all YAML strings in `file_yaml` and return result.
+    """Parse all YAML strings from `file_yaml` into `LocalManifestLists`.
+
+    Exclude all manifests that do not satisfy the `selectors`.
 
     Inputs:
         file_yaml: Dict[Filepath, str]

--- a/square/square.py
+++ b/square/square.py
@@ -713,7 +713,7 @@ def main() -> int:
     logit.info(f"Kubernetes version is {config.version}")
 
     # Do what user asked us to do.
-    selectors = Selectors(param.kinds, param.namespaces, param.labels)
+    selectors = Selectors(param.kinds, param.namespaces, set(param.labels))
     if param.parser == "get":
         _, err = main_get(config, client, param.folder, selectors)
     elif param.parser == "plan":

--- a/square/square.py
+++ b/square/square.py
@@ -668,7 +668,7 @@ def main_get(
         assert not err and server is not None
 
         # Sync the server manifests into the local manifests. All this happens in
-        # memory and no files will be modified here - see next step.
+        # memory and no files will be modified here - see `manio.save` in the next step.
         synced_manifests, err = manio.sync(local_files, server, selectors)
         assert not err and synced_manifests
 

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -239,9 +239,9 @@ class TestYamlManifestIO:
         }
         assert manio.parse(fdata_test_in, selectors) == (expected, False)
 
-        # Add a superfluous "---" at the beginning/end of the document. This
-        # mast not throw the parser and it must not include it in the output as
-        # an empty document.
+        # Add a superfluous "---" at the beginning or end of the document. The
+        # function must silently remove the empty document the YAML parser
+        # would produce.
         fdata_test_blank_pre = copy.deepcopy(fdata_test_in)
         fdata_test_blank_post = copy.deepcopy(fdata_test_in)
         fdata_test_blank_post["m2.yaml"] = fdata_test_blank_pre["m2.yaml"] + "\n---\n"

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -826,7 +826,7 @@ class TestMain:
             del args
 
         # Every main function must have been called exactly once.
-        selectors = Selectors(["Deployment", "Service"], None, tuple())
+        selectors = Selectors(["Deployment", "Service"], None, set())
         args = config, "client", "myfolder", selectors
         m_get.assert_called_once_with(*args)
         m_plan.assert_called_once_with(*args)
@@ -907,7 +907,7 @@ class TestMain:
         # Pretend all main functions return errors.
         m_cmd.return_value = types.SimpleNamespace(
             verbosity=0, parser="invalid", kubeconfig="conf", ctx="ctx",
-            folder=None, kinds=None, namespaces=None, labels=None
+            folder=None, kinds=None, namespaces=None, labels=set()
         )
         assert square.main() == 1
 

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -643,7 +643,7 @@ class TestMainOptions:
             m_delete.return_value = (None, False)
 
         # The arguments to the test function will always be the same in this test.
-        selectors = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        selectors = Selectors(["kinds"], ["ns"], {("foo", "bar"), ("x", "y")})
         args = config, "client", "folder", selectors
 
         # Square must never create/patch/delete anything if the user did not
@@ -720,7 +720,7 @@ class TestMainOptions:
         m_plan.return_value = (plan, False)
 
         # The arguments to the test function will always be the same in this test.
-        selectors = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        selectors = Selectors(["kinds"], ["ns"], {("foo", "bar"), ("x", "y")})
         args = "config", "client", "folder", selectors
 
         # A successfull DIFF only computes and prints the plan.
@@ -762,7 +762,7 @@ class TestMainOptions:
         m_save.return_value = (None, False)
 
         # The arguments to the test function will always be the same in this test.
-        selectors = Selectors(["kinds"], ["ns"], (("foo", "bar"), ("x", "y")))
+        selectors = Selectors(["kinds"], ["ns"], {("foo", "bar"), ("x", "y")})
         args = "config", "client", "folder", selectors
 
         # Call test function and verify it passed the correct arguments.


### PR DESCRIPTION
Refactored the logic to filter manifests. This PR ships no functional changes.

The new structure now defines an explicit `Selectors` data type which `manio.unpack_list` and `manio.parse` automatically apply. In turn, the old `square.prune` function has become redundant.