### PR TITLE
Bugfix: correctly select Secrets.

### DIFF
--- a/square/manio.py
+++ b/square/manio.py
@@ -75,6 +75,7 @@ def select(manifest: dict, selectors: Selectors) -> bool:
         if name.startswith("default-token-"):
             logit.debug("Skipping default token Secret")
             return False
+        ns = manifest.get("metadata", {}).get("namespace", None)
     else:
         ns = manifest.get("metadata", {}).get("namespace", None)
 

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -125,10 +125,14 @@ class TestHelpers:
         # ---------------------------------------------------------------------
         #                      Default Token Secret
         # ---------------------------------------------------------------------
-        # Iterate over (almost) all valid selectors.
+        # Must always ignore "default-token-*" Secrets.
         kind, ns = "Secret", "ns1"
         manifest = make_manifest(kind, ns, "default-token-12345")
         assert select(manifest, Selectors(kind, ns, set())) is False
+
+        # Must select all other Secret that match the selector.
+        manifest = make_manifest(kind, ns, "some-secret")
+        assert select(manifest, Selectors(kind, ns, set())) is True
 
 
 class TestUnpackParse:


### PR DESCRIPTION
Fixed corner case where `ns` variable in `manio.select` is undefined.