### PR TITLE
Refactor main function.

### DIFF
--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import pathlib
 import types
 import unittest.mock as mock
 
@@ -827,7 +828,7 @@ class TestMain:
 
         # Every main function must have been called exactly once.
         selectors = Selectors(["Deployment", "Service"], None, set())
-        args = config, "client", "myfolder", selectors
+        args = config, "client", pathlib.Path("myfolder"), selectors
         m_get.assert_called_once_with(*args)
         m_plan.assert_called_once_with(*args)
         m_apply.assert_called_once_with(*args)
@@ -907,7 +908,7 @@ class TestMain:
         # Pretend all main functions return errors.
         m_cmd.return_value = types.SimpleNamespace(
             verbosity=0, parser="invalid", kubeconfig="conf", ctx="ctx",
-            folder=None, kinds=None, namespaces=None, labels=set()
+            folder=pathlib.Path("/tmp"), kinds=None, namespaces=None, labels=set()
         )
         assert square.main() == 1
 


### PR DESCRIPTION
Refactors the main function to make it easier to use `square` as a library.
In particular, the setup of the K8s session is now a dedicated function. This should make it straightforward to call `square` as a library by mimicking the calls in `square.main`.