### PR TITLE
Integration test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Compiled 0 patches.
 foo@bar:~$ kubectl -n square get po
 NAME                     READY   STATUS    RESTARTS   AGE
 square-b6bc65f6d-2xmzm   1/1     Running   0          37s
-foo@bar:~$ 
+foo@bar:~$
 ```
 
 # Build The Binary
@@ -261,6 +261,23 @@ Build a shared library version of Python version with `pyenv`:
 This should produce the `./dist/square` executable.
 
 
+# Tests
+*Square* ships with a comprehensive unit test suit and a still nascent
+integration tests suite.
+
+To run the unit tests:
+
+    pipenv run pytest
+
+This will automatically run the integration tests as well if you have started
+the [KIND](https://github.com/bsycorp/kind) cluster:
+
+    cd deployment
+    ./start_minikube.sh
+    cd ..
+
+NOTE: currently, CI only runs the unit tests.
+
 # Development Status
 *Square* is still under development. Several rough edges remain but the core
-has become stable enough for more serious work.
+has become stable enough for serious work.

--- a/deployment/minikube-1-integration-tests.yaml
+++ b/deployment/minikube-1-integration-tests.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tests
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-secret
+  namespace: tests
+data:
+  mysecret: blah
+
+---
+
+apiVersion: v1
+data:
+  version: v1
+kind: ConfigMap
+metadata:
+  name: demo-configmap
+  namespace: tests
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demoapp
+  namespace: tests
+  labels:
+    app: demoapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demoapp
+  template:
+    metadata:
+      labels:
+        app: demoapp
+        tag: v1
+    spec:
+      containers:
+        - name: demoapp
+          image: alpine:latest
+          command: ["sleep", "100d"]

--- a/deployment/start_minikube.sh
+++ b/deployment/start_minikube.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e
+
+# ------------------------------------------------------------------------------
+#                            Bootstrap Kind Cluster
+# ------------------------------------------------------------------------------
+# Start the KIND container.
+docker run -dit --privileged -p 8443:8443 -p 10080:10080 bsycorp/kind:latest-1.13
+
+# Wait until the KIND cluster is operational.
+printf "\n\n### Booting KIND Cluster: "
+set +e
+while true; do
+    printf "."
+    sleep 1
+
+    # KIND provides an HTTP endpoint to ascertain whether or not it is ready yet.
+    curl http://localhost:10080/kubernetes-ready > /dev/null 2>/dev/null
+    if [ $? == 0 ]; then break; fi
+done
+set -e
+printf "done\n"
+
+# ------------------------------------------------------------------------------
+#                              Download Kubeconfig
+# ------------------------------------------------------------------------------
+# Download the Kubeconfig file into the /tmp folder. Once again, KIND provides
+# an HTTP endpoint to get it.
+KUBECONFIG=/tmp/kubeconfig-kind.yaml
+printf "### Downloading Kubeconfig to $KUBECONFIG: "
+curl http://localhost:10080/config >$KUBECONFIG 2>/dev/null
+printf "done\n"
+
+
+# ------------------------------------------------------------------------------
+#                          Deploy The Demo Resources
+# ------------------------------------------------------------------------------
+printf "### Deploy demo resources:\n"
+set +e
+
+# Apply the resource manifests until KIND accepts it. This may take a few
+# iterations because KIND, despite claiming it was ready earlier, often does not
+# accept the manifests straight away.
+while true; do
+    # Deploy the manifests.
+    kubectl --kubeconfig $KUBECONFIG --context kind apply -f minikube-1-integration-tests.yaml
+
+    # Exit this loop if deployment succeeded. If not, then KIND is not yet ready
+    # and we will try again shortly.
+    if [ $? == 0 ]; then break; fi
+    printf "\n   # Retry deployment...\n"
+    sleep 1
+done
+set -e
+printf "done\n"
+
+
+printf "\n\n### KIND cluster now fully deployed (KUBECONF=$KUBECONFIG)\n"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,47 @@
+import unittest.mock as mock
+
+import pytest
+import requests
+import square.square
+
+
+def kind_available():
+    """Return True if KIND cluster is available."""
+    try:
+        resp = requests.get("http://localhost:10080/kubernetes-ready")
+    except requests.ConnectionError:
+        return False
+    else:
+        return resp.status_code == 200
+
+
+@pytest.mark.skipif(not kind_available(), reason="No Minikube")
+class TestMain:
+    def test_main_get(self, tmp_path):
+        """GET all cluster resources."""
+        # Command line arguments.
+        args = (
+            "square.py", "get", "all",
+            "--folder", str(tmp_path),
+            "--kubeconfig", "/tmp/kubeconfig-kind.yaml",
+        )
+
+        # Temporary folder must be initially empty. After we pulled all
+        # resources, it must contain some files.
+        assert len(list(tmp_path.rglob("*.yaml"))) == 0
+        with mock.patch("sys.argv", args):
+            square.square.main()
+        assert len(list(tmp_path.rglob("*.yaml"))) > 0
+
+    def test_main_plan(self, tmp_path):
+        """PLAN all cluster resources."""
+        # Command line arguments.
+        args = (
+            "square.py", "plan", "all",
+            "--folder", str(tmp_path),
+            "--kubeconfig", "/tmp/kubeconfig-kind.yaml",
+        )
+
+        # Merely verify that the program does not break.
+        with mock.patch("sys.argv", args):
+            square.square.main()


### PR DESCRIPTION
* Add scaffolding for integration test suite.

The test suite is nascent at best and not part of the CI pipeline yet. Nevertheless, it already allows
to run the basic square commands to ensure it actually works with a real cluster. Subsequent PRs will gradually improve the integration tests.