### PR TITLE
Argument parsing

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -81,3 +81,15 @@ class ManifestGrouping(NamedTuple):
     """Define how to name manifest files on the files system."""
     label: str
     order: Iterable[str]
+
+
+class Configuration(NamedTuple):
+    command: str
+    verbosity: int
+    folder: Filepath
+    kinds: Iterable[str]
+    namespaces: Iterable[str]
+    kubeconfig: str
+    kube_ctx: Optional[str]
+    selectors: Selectors
+    groupby: ManifestGrouping

--- a/square/manio.py
+++ b/square/manio.py
@@ -396,7 +396,7 @@ def sync(
     del local_manifests
 
     # If the server's meta manifest exists locally then update the local one,
-    # otherwise add it to f"_{namespace}.yaml".
+    # otherwise add it to the catchall YAML file.
     for meta, manifest in server_manifests.items():
         try:
             # Find the file that defined `meta` and its position inside that file.

--- a/square/square.py
+++ b/square/square.py
@@ -698,7 +698,7 @@ def main_get(
 
 def cluster_config(
         kubeconfig: str,
-        kube_context: str) -> Tuple[Tuple[Optional[Config], Any], bool]:
+        context: Optional[str]) -> Tuple[Tuple[Optional[Config], Any], bool]:
     """Return web session to K8s API.
 
     This will read the Kubernetes credentials, contact Kubernetes to
@@ -716,11 +716,11 @@ def cluster_config(
     """
     # Read Kubeconfig file and use it to create a `requests` client session.
     # That session will have the proper security certificates and headers so
-    # that subsequent calls to K8s need not deal with anymore.
+    # that subsequent calls to K8s need not deal with it anymore.
     kubeconfig = os.path.expanduser(kubeconfig)
     try:
         # Parse Kubeconfig file.
-        config = k8s.load_auto_config(kubeconfig, kube_context, disable_warnings=True)
+        config = k8s.load_auto_config(kubeconfig, context, disable_warnings=True)
         assert config
 
         # Configure web session.

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -1547,6 +1547,28 @@ class TestSync:
         selectors = Selectors(kinds, namespaces, labels=None)
         assert manio.sync(loc_man, srv_man, selectors, groupby) == (expected, False)
 
+    def test_sync_filename_err(self):
+        """Must gracefully handle errors in `filename_for_manifest`.
+
+        This test will use an invalid grouping specification to force an error.
+        As a consequence, the function must abort cleanly and return an error.
+
+        """
+        # Valid selector for Deployment manifests.
+        selectors = Selectors(["Deployment"], namespaces=None, labels=None)
+
+        # Simulate the scenario where the server has a Deployment we lack
+        # locally. This will ensure that `sync` will try to create a new file
+        # for it, which is what we want to test.
+        loc_man = {}
+        srv_man = {manio.make_meta(mk_deploy(f"d_1", "ns1")): "1"}
+
+        # Define an invalid grouping specification. As a consequence,
+        # `filename_for_manifest` will return an error and we can verify if
+        # `sync` gracefully handles it and returns an error.
+        groupby = ManifestGrouping(order=["blah"], label="")
+        assert manio.sync(loc_man, srv_man, selectors, groupby) == (None, True)
+
 
 class TestDownloadManifests:
     @mock.patch.object(k8s, 'get')


### PR DESCRIPTION
Further improve the separation between *Square* as a library and *Square* as a standalone libary.
To this end, the PR introduces a new `dtypes.Configuration` type to cleanly encapsulate the arguments.

This PR makes no changes to the functionality of square but is part of an ongoing code refactoring.