### PR TITLE
Use kind cluster by default

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-KUBECONFIG=/does/not/exist
+KUBECONFIG=/tmp/kubeconfig-kind.yaml
 SQUARE_FOLDER=manifests/

--- a/square/square.py
+++ b/square/square.py
@@ -778,7 +778,7 @@ def main() -> int:
     # Initialise logging.
     setup_logging(cfg.verbosity)
 
-    # Create properly configured Requests session to talk with K8s API.
+    # Create properly configured Requests session to talk to K8s API.
     (config, client), err = cluster_config(cfg.kubeconfig, cfg.kube_ctx)
     if err or config is None or client is None:
         return 1

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1015,7 +1015,9 @@ class TestMain:
         with mock.patch.dict("os.environ", values=new_env, clear=True):
             # Square must use the supplied Kubeconfig file and ignore the
             # environment variable.
-            with mock.patch("sys.argv", ["square.py", "get", "svc", "--kubeconfig", "/file"]):  # noqa
+            with mock.patch(
+                    "sys.argv",
+                    ["square.py", "get", "svc", "--kubeconfig", "/file"]):
                 ret = square.parse_commandline_args()
                 assert ret.kubeconfig == "/file"
 


### PR DESCRIPTION
Point `KUBECONF` to the kind cluster by default. This changes nothing for the tests but makes it more convenient to play with Square locally.