### PR TITLE
Default folder for global resources

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,8 +68,8 @@ class TestMain:
 
         # Un-namespaced resources must be in special "_global_" folder.
         for kind in ["clusterrole", "clusterrolebinding"]:
-            assert (tmp_path / "demoapp" / f"{kind}.yaml").exists()
-            assert not (tmp_path / "demoapp" / f"{kind}.yaml").is_dir()
+            assert (tmp_path / "_global_" / "demoapp" / f"{kind}.yaml").exists()
+            assert not (tmp_path / "_global_" / "demoapp" / f"{kind}.yaml").is_dir()
 
     def test_main_plan(self, tmp_path):
         """PLAN all cluster resources."""

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -1213,13 +1213,13 @@ class TestSync:
             groupby = ManifestHierarchy(order=[], label="")
             assert fun(meta, man, groupby) == ("_other.yaml", False)
 
-            # Group by NAMESPACE and kind: must ignore the folder.
+            # Group by NAMESPACE and kind: must use "_global_" as folder name.
             groupby = ManifestHierarchy(order=["ns", "kind"], label="")
-            assert fun(meta, man, groupby) == (f"{kind.lower()}.yaml", False)
+            assert fun(meta, man, groupby) == (f"_global_/{kind.lower()}.yaml", False)
 
             # Group by KIND and NAMESPACE (inverse of previous test).
             groupby = ManifestHierarchy(order=["kind", "ns"], label="")
-            assert fun(meta, man, groupby) == (f"{kind.lower()}.yaml", False)
+            assert fun(meta, man, groupby) == (f"{kind.lower()}/_global_.yaml", False)
 
             # Group by the existing LABEL "app".
             groupby = ManifestHierarchy(order=["label"], label="app")


### PR DESCRIPTION
Place all global resources like `ClusterRole` into a `_global_` folder if the user wants to organise manifests by namespace (eg `--groupby ns`).

Previously, Square would have simply ignore the namespace when it constructs a file path which lead to unintuitive names. For instance, with `--groupby ns label=app kind`:
`./labelvalue/clusterrolebinding.yaml` (Before)
`./_global_/labelvalue/clusterrolebinding.yaml` (Now).