### PR TITLE
Library cleanups

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.1
+current_version = 0.16.0
 commit = True
 tag = False
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ square.spec
 # Personal folders.
 manifests/
 personal/
+
+# Other.
+delme*

--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ official [Docker image](https://hub.docker.com/r/olitheolix/square).
 This can be useful for automation tasks. For instance, you may want to
 track configuration drift of your cluster over time.
 
+# Use It As A Library
+See [here](examples/as_library.py) for an example of how to use Square as a
+library in your own Python programs.
+
 # Tests
 *Square* ships with a comprehensive unit test suit and a still nascent
 integration tests suite.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![](https://img.shields.io/badge/license-Apache%202-blue.svg)]()
 [![](https://img.shields.io/badge/python-3.7-blue.svg)]()
-[![](https://img.shields.io/badge/latest-v0.15.1-blue.svg)]()
+[![](https://img.shields.io/badge/latest-v0.16.0-blue.svg)]()
 [![](https://img.shields.io/circleci/project/github/olitheolix/square/master.svg?style=flat)]()
 [![](https://img.shields.io/codecov/c/github/olitheolix/square.svg?style=flat)]()
 [![](https://img.shields.io/badge/status-dev-orange.svg)]()
@@ -16,7 +16,7 @@ You can install *Square* in any Python 3.7 environment with:
 ```console
 foo@bar:~$ pip install kubernetes-square
 foo@bar:~$ square version
-0.15.1
+0.16.0
 ```
 
 You may also [build your own binary](Building-A-Binary), if you prefer.

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -1,3 +1,7 @@
+# Deploy Square
+This example is only useful if you want to run Square inside your cluster. You
+do not need to deploy anything to use it from your own terminal.
+
 These examples were tested with Minikube v1.10.0.
 
 The [manifest](square-single-namespace.yaml) deploys `square` into a new

--- a/examples/as_library.py
+++ b/examples/as_library.py
@@ -1,0 +1,39 @@
+"""Use Square as a library"""
+import os
+import pathlib
+
+import square
+from square.dtypes import ManifestHierarchy, Selectors
+
+
+def main():
+    # Define the necessary variables.
+    kubeconfig = pathlib.Path(os.environ["KUBECONFIG"])
+    kubectx = None
+    folder = pathlib.PosixPath('manifests')
+    selectors = Selectors(
+        kinds=["Deployment", "Service", "Namespace"],
+        labels={("app", "demoapp")},
+        namespaces=["square-tests"],
+    )
+    groupby = ManifestHierarchy(label="app", order=["ns", "label", "kind"])
+
+    # Optional: configures Square's logger.
+    square.square.setup_logging(0)
+
+    # Convenience.
+    common_args = kubeconfig, kubectx, folder, selectors
+
+    # Download manifests.
+    _, err = square.get(*common_args, groupby)
+
+    # Compute plan, then print it.
+    plan, err = square.plan(*common_args)
+    square.square.print_deltas(plan)
+
+    # Apply the plan.
+    _, err = square.apply(*common_args, plan, "yes")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kubernetes-square"
-version = "0.15.1"
+version = "0.16.0"
 description = ""
 authors = ["Oliver Nagy <olitheolix@gmail.com>"]
 packages = [

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -1,6 +1,6 @@
 from . import square
 
-__version__ = '0.15.1'
+__version__ = '0.16.0'
 
 # Expose the main functions directly for convenience.
 get = square.main_get

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -1,1 +1,8 @@
+from . import square
+
 __version__ = '0.15.1'
+
+# Expose the main functions directly for convenience.
+get = square.main_get
+plan = square.main_plan
+apply = square.main_apply

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -87,7 +87,6 @@ class ManifestHierarchy(NamedTuple):
 class Configuration(NamedTuple):
     command: str
     folder: Filepath
-    kinds: Iterable[str]
     selectors: Selectors
     groupby: ManifestHierarchy
     kubeconfig: str

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -86,13 +86,13 @@ class ManifestHierarchy(NamedTuple):
 
 class Configuration(NamedTuple):
     command: str
-    verbosity: int
     folder: Filepath
     kinds: Iterable[str]
-    kubeconfig: str
-    kube_ctx: Optional[str]
     selectors: Selectors
     groupby: ManifestHierarchy
+    kubeconfig: str
+    kube_ctx: Optional[str] = None
+    verbosity: int = 0
     k8s_config: K8sConfig = K8sConfig(
         url=None, token=None,
         ca_cert=None,

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -56,7 +56,7 @@ assert set(SUPPORTED_KINDS) == set(RESOURCE_ALIASES.keys())
 
 SUPPORTED_VERSIONS = ("1.9", "1.10", "1.11", "1.13", "1.14")
 
-Config = namedtuple('Config', 'url token ca_cert client_cert version name')
+K8sConfig = namedtuple('Config', 'url token ca_cert client_cert version name')
 DeltaCreate = namedtuple("DeltaCreate", "meta url manifest")
 DeltaDelete = namedtuple("DeltaDelete", "meta url manifest")
 DeltaPatch = namedtuple("Delta", "meta diff patch")
@@ -94,5 +94,5 @@ class Configuration(NamedTuple):
     kube_ctx: Optional[str]
     selectors: Selectors
     groupby: ManifestHierarchy
-    k8s_config: Config
+    k8s_config: K8sConfig
     k8s_client: Any

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,7 +1,7 @@
 import pathlib
 from collections import namedtuple
 from typing import (
-    Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union,
+    Any, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union,
 )
 
 # We support these resource types. The order matters because it determines the
@@ -94,3 +94,5 @@ class Configuration(NamedTuple):
     kube_ctx: Optional[str]
     selectors: Selectors
     groupby: ManifestHierarchy
+    k8s_config: Config
+    k8s_client: Any

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -94,5 +94,11 @@ class Configuration(NamedTuple):
     kube_ctx: Optional[str]
     selectors: Selectors
     groupby: ManifestHierarchy
-    k8s_config: K8sConfig
-    k8s_client: Any
+    k8s_config: K8sConfig = K8sConfig(
+        url=None, token=None,
+        ca_cert=None,
+        client_cert=None,
+        version=None,
+        name=None
+    )
+    k8s_client: Any = None

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -89,7 +89,6 @@ class Configuration(NamedTuple):
     verbosity: int
     folder: Filepath
     kinds: Iterable[str]
-    namespaces: Iterable[str]
     kubeconfig: str
     kube_ctx: Optional[str]
     selectors: Selectors

--- a/square/main.py
+++ b/square/main.py
@@ -217,9 +217,14 @@ def compile_config(cmdline_param) -> Tuple[Optional[Configuration], bool]:
     # Assemble the full configuration and return it.
     # -------------------------------------------------------------------------
     cfg = Configuration(
-        p.parser, p.verbosity, folder,
-        p.kinds, p.kubeconfig, p.ctx,
-        selectors, groupby,
+        command=p.parser,
+        verbosity=p.verbosity,
+        folder=folder,
+        kinds=p.kinds,
+        kubeconfig=p.kubeconfig,
+        kube_ctx=p.ctx,
+        selectors=selectors,
+        groupby=groupby,
     )
     return cfg, False
 

--- a/square/main.py
+++ b/square/main.py
@@ -11,7 +11,7 @@ import square
 import square.square
 from square import __version__
 from square.dtypes import (
-    RESOURCE_ALIASES, SUPPORTED_KINDS, Config, Configuration,
+    RESOURCE_ALIASES, SUPPORTED_KINDS, Configuration, K8sConfig,
     ManifestHierarchy, Selectors,
 )
 
@@ -222,8 +222,8 @@ def compile_config(cmdline_param) -> Tuple[Optional[Configuration], bool]:
         p.kubeconfig, p.ctx,
         selectors, groupby,
         # We cannot populate the Kubernetes config/client fields here.
-        Config(url=None, token=None, ca_cert=None,
-               client_cert=None, version=None, name=None),
+        K8sConfig(url=None, token=None, ca_cert=None,
+                  client_cert=None, version=None, name=None),
         None,
     )
     return cfg, False

--- a/square/main.py
+++ b/square/main.py
@@ -247,7 +247,8 @@ def main() -> int:
     if cfg.command == "get":
         _, err = square.square.main_get(*common_args, cfg.groupby)
     elif cfg.command == "plan":
-        _, err = square.square.main_plan(*common_args)
+        plan, err = square.square.main_plan(*common_args)
+        square.square.print_deltas(plan)
     elif cfg.command == "apply":
         _, err = square.square.main_apply(*common_args, None, "yes")
     else:

--- a/square/main.py
+++ b/square/main.py
@@ -220,7 +220,6 @@ def compile_config(cmdline_param) -> Tuple[Optional[Configuration], bool]:
         command=p.parser,
         verbosity=p.verbosity,
         folder=folder,
-        kinds=p.kinds,
         kubeconfig=p.kubeconfig,
         kube_ctx=p.ctx,
         selectors=selectors,

--- a/square/main.py
+++ b/square/main.py
@@ -11,8 +11,8 @@ import square
 import square.square
 from square import __version__
 from square.dtypes import (
-    RESOURCE_ALIASES, SUPPORTED_KINDS, Configuration, K8sConfig,
-    ManifestHierarchy, Selectors,
+    RESOURCE_ALIASES, SUPPORTED_KINDS, Configuration, ManifestHierarchy,
+    Selectors,
 )
 
 # Convenience: global logger instance to avoid repetitive code.
@@ -218,8 +218,7 @@ def compile_config(cmdline_param) -> Tuple[Optional[Configuration], bool]:
     # -------------------------------------------------------------------------
     cfg = Configuration(
         p.parser, p.verbosity, folder,
-        p.kinds, p.namespaces,
-        p.kubeconfig, p.ctx,
+        p.kinds, p.kubeconfig, p.ctx,
         selectors, groupby,
     )
     return cfg, False

--- a/square/main.py
+++ b/square/main.py
@@ -255,7 +255,7 @@ def main() -> int:
     elif cfg.command == "plan":
         _, err = square.square.main_plan(*common_args)
     elif cfg.command == "apply":
-        _, err = square.square.main_apply(*common_args, cfg.k8s_config.name)
+        _, err = square.square.main_apply(*common_args, None, cfg.k8s_config.name)
     else:
         logit.error(f"Unknown command <{cfg.command}>")
         return 1

--- a/square/main.py
+++ b/square/main.py
@@ -243,9 +243,11 @@ def main() -> int:
         return 1
 
     # Create properly configured Requests session to talk to K8s API.
-    cfg, err = square.square.cluster_config(cfg)
-    if err or cfg is None:
+    (k8s_config, k8s_client), err = square.square.cluster_config(
+        cfg.kubeconfig, cfg.kube_ctx)
+    if err or k8s_config is None or k8s_client is None:
         return 1
+    cfg = cfg._replace(k8s_config=k8s_config, k8s_client=k8s_client)
 
     # Do what user asked us to do.
     common_args = cfg.k8s_config, cfg.k8s_client, cfg.folder, cfg.selectors

--- a/square/main.py
+++ b/square/main.py
@@ -242,21 +242,14 @@ def main() -> int:
     if cfg is None or err:
         return 1
 
-    # Create properly configured Requests session to talk to K8s API.
-    (k8s_config, k8s_client), err = square.square.cluster_config(
-        cfg.kubeconfig, cfg.kube_ctx)
-    if err or k8s_config is None or k8s_client is None:
-        return 1
-    cfg = cfg._replace(k8s_config=k8s_config, k8s_client=k8s_client)
-
     # Do what user asked us to do.
-    common_args = cfg.k8s_config, cfg.k8s_client, cfg.folder, cfg.selectors
+    common_args = cfg.kubeconfig, cfg.kube_ctx, cfg.folder, cfg.selectors
     if cfg.command == "get":
         _, err = square.square.main_get(*common_args, cfg.groupby)
     elif cfg.command == "plan":
         _, err = square.square.main_plan(*common_args)
     elif cfg.command == "apply":
-        _, err = square.square.main_apply(*common_args, None, cfg.k8s_config.name)
+        _, err = square.square.main_apply(*common_args, None, "yes")
     else:
         logit.error(f"Unknown command <{cfg.command}>")
         return 1

--- a/square/main.py
+++ b/square/main.py
@@ -221,10 +221,6 @@ def compile_config(cmdline_param) -> Tuple[Optional[Configuration], bool]:
         p.kinds, p.namespaces,
         p.kubeconfig, p.ctx,
         selectors, groupby,
-        # We cannot populate the Kubernetes config/client fields here.
-        K8sConfig(url=None, token=None, ca_cert=None,
-                  client_cert=None, version=None, name=None),
-        None,
     )
     return cfg, False
 

--- a/square/manio.py
+++ b/square/manio.py
@@ -11,7 +11,7 @@ import square.schemas
 import yaml
 import yaml.scanner
 from square.dtypes import (
-    SUPPORTED_KINDS, Config, Filepath, LocalManifestLists, LocalManifests,
+    SUPPORTED_KINDS, Filepath, K8sConfig, LocalManifestLists, LocalManifests,
     ManifestHierarchy, MetaManifest, Selectors, ServerManifests,
 )
 
@@ -476,7 +476,7 @@ def filename_for_manifest(
 
 
 def diff(
-        config: Config,
+        config: K8sConfig,
         local: LocalManifests,
         server: ServerManifests) -> Tuple[Optional[str], bool]:
     """Return the human readable diff between the `local` and `server`.
@@ -485,7 +485,7 @@ def diff(
     into the state of the `local` manifest.
 
     Inputs:
-        config: Config
+        config: K8sConfig
         local: dict
             Local manifest.
         server: dict
@@ -515,7 +515,7 @@ def diff(
     return (str.join("\n", diff_lines), False)
 
 
-def strip(config: Config, manifest: dict) -> Tuple[Optional[DotDict], bool]:
+def strip(config: K8sConfig, manifest: dict) -> Tuple[Optional[DotDict], bool]:
     """Return stripped version of `manifest` with only the essential keys.
 
     The "essential" keys for each supported resource type are defined in the
@@ -524,7 +524,7 @@ def strip(config: Config, manifest: dict) -> Tuple[Optional[DotDict], bool]:
     information like "metadata.creationTimestamp" or "status".
 
     Inputs:
-        config: Config
+        config: K8sConfig
         manifest: dict
 
     Returns:
@@ -794,7 +794,7 @@ def save(folder: Filepath, manifests: LocalManifestLists) -> Tuple[None, bool]:
 
 
 def download(
-        config: Config,
+        config: K8sConfig,
         client,
         selectors: Selectors,
 ) -> Tuple[Optional[ServerManifests], bool]:
@@ -806,7 +806,7 @@ def download(
     Either returns all the data or an error; never returns partial results.
 
     Inputs:
-        config: Config
+        config: K8sConfig
         client: `requests` session with correct K8s certificates.
         selectors: Selectors
 

--- a/square/square.py
+++ b/square/square.py
@@ -206,7 +206,7 @@ def compile_plan(
     return (DeploymentPlan(create, patches, delete), False)
 
 
-def print_deltas(plan: DeploymentPlan) -> Tuple[None, bool]:
+def print_deltas(plan: Optional[DeploymentPlan]) -> Tuple[None, bool]:
     """Print human readable version of `plan` to terminal.
 
     Inputs:
@@ -216,6 +216,11 @@ def print_deltas(plan: DeploymentPlan) -> Tuple[None, bool]:
         None
 
     """
+    # Do nothing if the plan is `None`. This special case makes it easier to
+    # deal with cases where `square.main_plan` returns an error.
+    if not plan:
+        return (None, False)
+
     # Terminal colours for convenience.
     cAdd = colorama.Fore.GREEN
     cDel = colorama.Fore.RED
@@ -512,7 +517,6 @@ def main_plan(
         return (None, True)
 
     # Print the plan and return.
-    print_deltas(plan)
     return (plan, False)
 
 

--- a/square/square.py
+++ b/square/square.py
@@ -9,9 +9,9 @@ import square.k8s as k8s
 import square.manio as manio
 import yaml
 from square.dtypes import (
-    Config, Configuration, DeltaCreate, DeltaDelete, DeltaPatch,
-    DeploymentPlan, Filepath, JsonPatch, ManifestHierarchy, MetaManifest,
-    Selectors, ServerManifests,
+    Configuration, DeltaCreate, DeltaDelete, DeltaPatch, DeploymentPlan,
+    Filepath, JsonPatch, K8sConfig, ManifestHierarchy, MetaManifest, Selectors,
+    ServerManifests,
 )
 
 # Convenience: global logger instance to avoid repetitive code.
@@ -19,7 +19,7 @@ logit = logging.getLogger("square")
 
 
 def make_patch(
-        config: Config,
+        config: K8sConfig,
         local: ServerManifests,
         server: ServerManifests) -> Tuple[Optional[JsonPatch], bool]:
     """Return JSON patch to transition `server` to `local`.
@@ -128,7 +128,7 @@ def partition_manifests(
 
 
 def compile_plan(
-        config: Config,
+        config: K8sConfig,
         local: ServerManifests,
         server: ServerManifests) -> Tuple[Optional[DeploymentPlan], bool]:
     """Return the `DeploymentPlan` to transition K8s to state of `local`.
@@ -138,7 +138,7 @@ def compile_plan(
     specified in `local`.
 
     Inputs:
-        config: Config
+        config: K8sConfig
         local: ServerManifests
             Should be output from `load_manifest` or `load`.
         server: ServerManifests
@@ -387,7 +387,7 @@ def user_confirmed(answer: Optional[str] = "yes") -> bool:
 
 
 def main_apply(
-        config: Config,
+        config: K8sConfig,
         client,
         folder: Filepath,
         selectors: Selectors,
@@ -399,7 +399,7 @@ def main_apply(
     `server_manifests` to the desired `local_manifests`.
 
     Inputs:
-        config: Config
+        config: K8sConfig
         client: `requests` session with correct K8s certificates.
         folder: Filepath
             Path to local manifests eg "./foo"
@@ -460,7 +460,7 @@ def main_apply(
 
 
 def main_plan(
-        config: Config,
+        config: K8sConfig,
         client,
         folder: Filepath,
         selectors: Selectors,
@@ -471,7 +471,7 @@ def main_plan(
     to match the setup defined in `local_manifests`.
 
     Inputs:
-        config: k8s.Config
+        config: K8sConfig
         client: `requests` session with correct K8s certificates.
         folder: Path
             Path to local manifests eg "./foo"
@@ -503,7 +503,7 @@ def main_plan(
 
 
 def main_get(
-        config: Config,
+        config: K8sConfig,
         client,
         folder: Filepath,
         selectors: Selectors,
@@ -513,7 +513,7 @@ def main_get(
     """Download all K8s manifests and merge them into local files.
 
     Inputs:
-        config: k8s.Config
+        config: K8sConfig
         client: `requests` session with correct K8s certificates.
         folder: Path
             Path to local manifests eg "./foo"

--- a/square/square.py
+++ b/square/square.py
@@ -474,7 +474,7 @@ def main_plan(
         client,
         folder: Filepath,
         selectors: Selectors,
-) -> Tuple[None, bool]:
+) -> Tuple[Optional[DeploymentPlan], bool]:
     """Print the diff between `local_manifests` and `server_manifests`.
 
     The diff shows what would have to change on the K8s server in order for it
@@ -489,7 +489,7 @@ def main_plan(
             Only operate on resources that match the selectors.
 
     Returns:
-        None
+        Deployment plan.
 
     """
     try:
@@ -509,7 +509,7 @@ def main_plan(
 
     # Print the plan and return.
     print_deltas(plan)
-    return (None, False)
+    return (plan, False)
 
 
 def main_get(

--- a/square/square.py
+++ b/square/square.py
@@ -391,7 +391,8 @@ def main_apply(
         client,
         folder: Filepath,
         selectors: Selectors,
-        confirm_string: Optional[str]
+        plan: Optional[DeploymentPlan],
+        confirm_string: Optional[str],
 ) -> Tuple[None, bool]:
     """Update K8s to match the specifications in `local_manifests`.
 
@@ -405,6 +406,8 @@ def main_apply(
             Path to local manifests eg "./foo"
         selectors: Selectors
             Only operate on resources that match the selectors.
+        plan: DeploymentPlan
+            Run a plan if `None`, or use the supplied `plan`.
         confirm_string:
             Only apply the plan if user answers with this string in the
         confirmation dialog (set to `None` to disable confirmation).
@@ -415,8 +418,9 @@ def main_apply(
     """
     try:
         # Obtain the plan.
-        plan, err = main_plan(config, client, folder, selectors)
-        assert not err and plan
+        if not plan:
+            plan, err = main_plan(config, client, folder, selectors)
+            assert not err and plan
 
         # Exit prematurely if there are no changes to apply.
         num_patch_ops = sum([len(_.patch.ops) for _ in plan.patch])

--- a/square/square.py
+++ b/square/square.py
@@ -413,20 +413,9 @@ def main_apply(
 
     """
     try:
-        # Load manifests from local files.
-        local_meta, _, err = manio.load(folder, selectors)
-        assert not err and local_meta is not None
-
-        # Download manifests from K8s.
-        server, err = manio.download(config, client, selectors)
-        assert not err and server is not None
-
-        # Create the deployment plan.
-        plan, err = compile_plan(config, local_meta, server)
-        assert not err and plan is not None
-
-        # Present the plan to the user.
-        print_deltas(plan)
+        # Obtain the plan.
+        plan, err = main_plan(config, client, folder, selectors)
+        assert not err
 
         # Exit prematurely if there are no changes to apply.
         num_patch_ops = sum([len(_.patch.ops) for _ in plan.patch])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import unittest.mock as mock
+
+import pytest
 import square.square
 
 
@@ -5,3 +8,10 @@ def pytest_configure(*args, **kwargs):
     """Pytest calls this hook on startup."""
     # Set log level to DEBUG for all unit tests.
     square.square.setup_logging(9)
+
+
+@pytest.fixture
+def kube_creds(request):
+    with mock.patch.object(square.square, "cluster_config") as m:
+        m.return_value = (("k8s_config", "k8s_client"), False)
+        yield m

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,11 +4,10 @@ import types
 import unittest.mock as mock
 
 import pytest
-import square.k8s as k8s
 import square.main as main
 import square.square as square
 from square.dtypes import (
-    SUPPORTED_KINDS, Config, Configuration, ManifestHierarchy, Selectors,
+    SUPPORTED_KINDS, Configuration, K8sConfig, ManifestHierarchy, Selectors,
 )
 
 
@@ -49,7 +48,7 @@ class TestMain:
             ),
             groupby=ManifestHierarchy(label='', order=[]),
             # Must not populate Kubernetes data.
-            k8s_config=Config(
+            k8s_config=K8sConfig(
                 url=None, token=None, ca_cert=None,
                 client_cert=None, version=None, name=None),
             k8s_client=None,
@@ -135,7 +134,7 @@ class TestMain:
 
         """
         # Dummy configuration.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Default grouping because we will not specify custom ones in this test.
         groupby = ManifestHierarchy(order=[], label="")
@@ -202,7 +201,7 @@ class TestMain:
 
         """
         # Dummy configuration.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Mock all calls to the K8s API.
         m_k8s.load_auto_config.return_value = config

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -161,7 +161,7 @@ class TestMain:
         args = config, "client", pathlib.Path("myfolder"), selectors
         m_get.assert_called_once_with(*args, groupby)
         m_plan.assert_called_once_with(*args)
-        m_apply.assert_called_once_with(*args, config.name)
+        m_apply.assert_called_once_with(*args, None, config.name)
 
     def test_main_version(self):
         """Simulate "version" command."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -225,29 +225,19 @@ class TestMain:
         harmless gaps in the unit test coverage.
 
         """
-        # A valid Square configuration.
-        cfg = Configuration(
-            command='get', verbosity=9, folder=pathlib.Path('/tmp'),
-            kubeconfig='kubeconfig', kube_ctx=None,
-            selectors=Selectors(
-                kinds=['Deployment'],
-                namespaces=['default'],
-                labels={("app", "morty"), ("foo", "bar")}
-            ),
-            groupby=ManifestHierarchy(label='', order=[]),
-        )
-        m_cluster.return_value = (cfg, False)
+        # Pretend the call to get K8s credentials succeeded.
+        m_cluster.return_value = (("foo", "bar"), False)
 
-        # Force a configuration error in `compile_config` due to the missing
-        # K8s credentials.
+        # Force a configuration error due to the absence of K8s credentials.
         cmd_args = dummy_command_param()
         cmd_args.kubeconfig = None
         m_cmd.return_value = cmd_args
         assert main.main() == 1
 
         # Simulate an invalid Square command.
-        m_cmd.return_value = dummy_command_param()
-        m_cluster.return_value = (cfg._replace(command="invalid"), False)
+        cmd_args = dummy_command_param()
+        cmd_args.parser = "invalid"
+        m_cmd.return_value = cmd_args
         assert main.main() == 1
 
     @mock.patch.object(square, "k8s")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,7 +39,6 @@ class TestMain:
         assert cfg == Configuration(
             command='get', verbosity=9, folder=pathlib.Path('/tmp'),
             kinds=['Deployment'],
-            namespaces=['default'],
             kubeconfig='kubeconfig', kube_ctx=None,
             selectors=Selectors(
                 kinds=['Deployment'],
@@ -231,7 +230,6 @@ class TestMain:
         cfg = Configuration(
             command='get', verbosity=9, folder=pathlib.Path('/tmp'),
             kinds=['Deployment'],
-            namespaces=['default'],
             kubeconfig='kubeconfig', kube_ctx=None,
             selectors=Selectors(
                 kinds=['Deployment'],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -239,8 +239,6 @@ class TestMain:
                 labels={("app", "morty"), ("foo", "bar")}
             ),
             groupby=ManifestHierarchy(label='', order=[]),
-            # Must not populate Kubernetes data.
-            k8s_config=None, k8s_client=None,
         )
         m_cluster.return_value = (cfg, False)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,7 +38,6 @@ class TestMain:
         assert not err
         assert cfg == Configuration(
             command='get', verbosity=9, folder=pathlib.Path('/tmp'),
-            kinds=['Deployment'],
             kubeconfig='kubeconfig', kube_ctx=None,
             selectors=Selectors(
                 kinds=['Deployment'],
@@ -60,19 +59,19 @@ class TestMain:
         param.kinds = ["Service", "Deploy", "Service"]
         cfg, err = main.compile_config(param)
         assert not err
-        assert cfg.kinds == ["Service", "Deploy"]
+        assert cfg.selectors.kinds == ["Service", "Deploy"]
 
         # The "all" resource must expand to all supported kinds.
         param.kinds = ["all"]
         cfg, err = main.compile_config(param)
         assert not err
-        assert cfg.kinds == list(SUPPORTED_KINDS)
+        assert cfg.selectors.kinds == list(SUPPORTED_KINDS)
 
         # Must remove duplicate resources.
         param.kinds = ["all", "svc", "all"]
         cfg, err = main.compile_config(param)
         assert not err
-        assert cfg.kinds == list(SUPPORTED_KINDS)
+        assert cfg.selectors.kinds == list(SUPPORTED_KINDS)
 
     def test_compile_config_k8s_credentials(self):
         """Parse K8s credentials."""
@@ -229,7 +228,6 @@ class TestMain:
         # A valid Square configuration.
         cfg = Configuration(
             command='get', verbosity=9, folder=pathlib.Path('/tmp'),
-            kinds=['Deployment'],
             kubeconfig='kubeconfig', kube_ctx=None,
             selectors=Selectors(
                 kinds=['Deployment'],

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -9,8 +9,8 @@ import square.manio as manio
 import square.schemas as schemas
 import yaml
 from square.dtypes import (
-    SUPPORTED_KINDS, SUPPORTED_VERSIONS, ManifestHierarchy, MetaManifest,
-    Selectors,
+    SUPPORTED_KINDS, SUPPORTED_VERSIONS, K8sConfig, ManifestHierarchy,
+    MetaManifest, Selectors,
 )
 from square.k8s import urlpath
 
@@ -667,7 +667,7 @@ class TestManifestValidation:
 
         """
         version = "1.10"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", version, "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", version, "")
         schema = {
             "invalid": False,
             "metadata": {
@@ -755,7 +755,7 @@ class TestManifestValidation:
 
         """
         version = "1.10"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", version, "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", version, "")
         schema = {
             "metadata": {
                 "name": None,
@@ -788,7 +788,7 @@ class TestManifestValidation:
     def test_strip_invalid_schema(self):
         """Create a corrupt schema and verify we get a proper error message."""
         version = "1.10"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", version, "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", version, "")
         schema = {version: {"TEST": {"invalid": "foo"}}}
 
         with mock.patch("square.schemas.RESOURCE_SCHEMA", schema):
@@ -803,18 +803,18 @@ class TestManifestValidation:
 
         with mock.patch("square.schemas.RESOURCE_SCHEMA", schema):
             # Valid version but unknown resource.
-            config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+            config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
             manifest = {"apiVersion": "v1", "kind": "Unknown"}
             assert manio.strip(config, manifest) == (None, True)
 
             # Invalid version but known resource.
-            config = k8s.Config("url", "token", "ca_cert", "client_cert", "unknown", "")
+            config = K8sConfig("url", "token", "ca_cert", "client_cert", "unknown", "")
             manifest = {"apiVersion": "v1", "kind": "TEST"}
             assert manio.strip(config, manifest) == (None, True)
 
     def test_strip_namespace(self):
         """Validate NAMESPACE manifests."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid namespace manifest with a few optional and irrelevant keys.
         valid = {
@@ -845,7 +845,7 @@ class TestManifestValidation:
 
     def test_strip_service(self):
         """Validate SERVICE manifests."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid service manifest with a few optional and irrelevant keys.
         valid = {
@@ -904,7 +904,7 @@ class TestManifestValidation:
 
     def test_strip_deployment(self):
         """Validate DEPLOYMENT manifests."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid service manifest with a few optional and irrelevant keys.
         valid = {
@@ -951,7 +951,7 @@ class TestDiff:
     def test_diff_ok(self):
         """Diff two valid manifests and (roughly) verify the output."""
         # Dummy config for (only "version" is relevant).
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Two valid manifests.
         srv = make_manifest("Deployment", "namespace", "name1")
@@ -974,7 +974,7 @@ class TestDiff:
     def test_diff_err(self):
         """Diff two valid manifests and verify the output."""
         # Dummy config for (only "version" is relevant).
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Create two valid manifests, then stunt one in such a way that
         # `essential` will reject it.
@@ -1579,7 +1579,7 @@ class TestDownloadManifests:
         actually execute.
 
         """
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
         meta = [
             make_manifest("Namespace", None, "ns0"),
             make_manifest("Namespace", None, "ns1"),
@@ -1692,7 +1692,7 @@ class TestDownloadManifests:
     @mock.patch.object(k8s, 'get')
     def test_download_err(self, m_get):
         """Simulate a download error."""
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # A valid NamespaceList with one element.
         man_list_ns = {

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -7,7 +7,7 @@ import square.k8s as k8s
 import square.manio as manio
 import square.square as square
 from square.dtypes import (
-    DeltaCreate, DeltaDelete, DeltaPatch, DeploymentPlan, JsonPatch,
+    DeltaCreate, DeltaDelete, DeltaPatch, DeploymentPlan, JsonPatch, K8sConfig,
     ManifestHierarchy, MetaManifest, Selectors,
 )
 from square.k8s import urlpath
@@ -196,7 +196,7 @@ class TestPatchK8s:
         """Basic test: compute patch between two identical resources."""
         # Setup.
         kind, ns, name = 'Deployment', 'ns', 'foo'
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # PATCH URLs require the resource name at the end of the request path.
         url = urlpath(config, kind, ns)[0] + f'/{name}'
@@ -216,7 +216,7 @@ class TestPatchK8s:
 
         """
         # Setup.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Demo manifest.
         srv = make_manifest('Deployment', 'Namespace', 'name')
@@ -283,7 +283,7 @@ class TestPatchK8s:
         """Coverage gap: simulate `urlpath` error."""
         # Setup.
         kind, ns, name = "Deployment", "ns", "foo"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Simulate `urlpath` error.
         m_url.return_value = (None, True)
@@ -303,7 +303,7 @@ class TestPlan:
         label and one to add the new ones.
 
         """
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Two valid manifests.
         kind, namespace, name = "Deployment", "namespace", "name"
@@ -332,8 +332,8 @@ class TestPlan:
 
     def test_make_patch_err(self):
         """Verify error cases with invalid or incompatible manifests."""
-        valid_cfg = k8s.Config("url", "token", "cert", "client_cert", "1.10", "")
-        invalid_cfg = k8s.Config("url", "token", "cert", "client_cert", "invalid", "")
+        valid_cfg = K8sConfig("url", "token", "cert", "client_cert", "1.10", "")
+        invalid_cfg = K8sConfig("url", "token", "cert", "client_cert", "invalid", "")
 
         # Create two valid manifests, then stunt one in such a way that
         # `manio.strip` will reject it.
@@ -365,7 +365,7 @@ class TestPlan:
 
         """
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Allocate arrays for the MetaManifests and resource URLs.
         meta = [None] * 5
@@ -430,7 +430,7 @@ class TestPlan:
     def test_compile_plan_create_delete_err(self, m_part):
         """Simulate `urlpath` errors"""
         # Invalid configuration. We will use it to trigger an error in `urlpath`.
-        cfg_invalid = k8s.Config("url", "token", "cert", "cert", "invalid", "")
+        cfg_invalid = K8sConfig("url", "token", "cert", "cert", "invalid", "")
 
         # Valid ManifestMeta and dummy manifest dict.
         meta = manio.make_meta(make_manifest("Deployment", "ns", "name"))
@@ -461,7 +461,7 @@ class TestPlan:
 
         """
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Allocate arrays for the MetaManifests.
         meta = [None] * 4
@@ -508,7 +508,7 @@ class TestPlan:
 
         """
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Define a single resource.
         meta = MetaManifest('v1', 'Namespace', None, 'ns1')
@@ -541,7 +541,7 @@ class TestPlan:
     def test_compile_plan_err(self, m_apply, m_plan, m_part):
         """Use mocks for the internal function calls to simulate errors."""
         # Create vanilla `Config` instance.
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", "")
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
 
         # Define a single resource and valid dummy return value for
         # `square.partition_manifests`.
@@ -584,7 +584,7 @@ class TestMainOptions:
         """
         # Valid client config and MetaManifest.
         cname = "clustername"
-        config = k8s.Config("url", "token", "ca_cert", "client_cert", "1.10", cname)
+        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", cname)
         meta = manio.make_meta(make_manifest("Deployment", "ns", "name"))
 
         # Valid Patch.

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -715,7 +715,8 @@ class TestMainOptions:
         args = "config", "client", "folder", selectors
 
         # A successfull DIFF only computes and prints the plan.
-        assert square.main_plan(*args) == (None, False)
+        plan, err = square.main_plan(*args)
+        assert not err and isinstance(plan, DeploymentPlan)
         m_load.assert_called_once_with("folder", selectors)
         m_down.assert_called_once_with("config", "client", selectors)
         m_plan.assert_called_once_with("config", "local", "server")


### PR DESCRIPTION
No user facing changes but several internal ones.

This PR ships mostly cleanups to make Square usable as a library.

The most notable points are:
* `main_plan` now returns the explict plan and does not print it anymore.
* `main_apply` now accepts an (optional) plan.
* Remove unused fields from `dtypes.Config`.
* Renamed `dtypes.Config` -> `dtypes.K8sConfig`.
* Make Square easier to use as a library.
* Bump version to v0.16.0