### PR TITLE
Bugfix: print non-unique files without error.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2
 commit = True
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![](https://img.shields.io/badge/license-Apache%202-blue.svg)]()
 [![](https://img.shields.io/badge/python-3.7+-blue.svg)]()
-[![](https://img.shields.io/badge/latest-v0.17.1-blue.svg)]()
+[![](https://img.shields.io/badge/latest-v0.17.2-blue.svg)]()
 [![](https://img.shields.io/circleci/project/github/olitheolix/square/master.svg?style=flat)]()
 [![](https://img.shields.io/codecov/c/github/olitheolix/square.svg?style=flat)]()
 [![](https://img.shields.io/badge/status-prod-green.svg)]()
@@ -16,7 +16,7 @@ You can install *Square* in any Python 3.7+ environment with:
 ```console
 foo@bar:~$ pip install kubernetes-square
 foo@bar:~$ square version
-0.17.1
+0.17.2
 ```
 
 Some pre-built binaries are available on the [Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kubernetes-square"
-version = "0.17.1"
+version = "0.17.2"
 description = ""
 authors = ["Oliver Nagy <olitheolix@gmail.com>"]
 packages = [

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -1,6 +1,6 @@
 from . import square
 
-__version__ = '0.17.1'
+__version__ = '0.17.2'
 
 # Expose the main functions of Square directly for convenience.
 get = square.get_resources

--- a/square/manio.py
+++ b/square/manio.py
@@ -261,9 +261,10 @@ def unpack(manifests: LocalManifestLists) -> Tuple[Optional[ServerManifests], bo
     for meta, fnames in all_meta.items():
         if len(fnames) > 1:
             unique = False
+            tmp = [str(_) for _ in fnames]
             logit.error(
-                f"Duplicate ({len(fnames)}x) manifest {meta}. "
-                f"Defined in {str.join(', ', fnames)}"
+                f"Duplicate ({len(tmp)}x) manifest {meta}. "
+                f"Defined in {str.join(', ', tmp)}"
             )
     if not unique:
         return (None, True)

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -417,17 +417,18 @@ class TestYamlManifestIO:
 
     def test_unpack_err(self):
         """The MetaManifests must be unique across all source files."""
+        P = Filepath
 
         # Two resources with same meta information in same file.
         src = {
-            "file0.txt": [("meta0", "manifest0"), ("meta0", "manifest0")],
+            P("file0.txt"): [("meta0", "manifest0"), ("meta0", "manifest0")],
         }
         assert manio.unpack(src) == (None, True)
 
         # Two resources with same meta information in different files.
         src = {
-            "file0.txt": [("meta0", "manifest0")],
-            "file1.txt": [("meta0", "manifest0")],
+            P("file0.txt"): [("meta0", "manifest0")],
+            P("file1.txt"): [("meta0", "manifest0")],
         }
         assert manio.unpack(src) == (None, True)
 


### PR DESCRIPTION
Fix a small bug with the error message that tells the user that not all manifests are unique.