### PR TITLE
Add `align_serviceaccounts` function.

### DIFF
--- a/square/square.py
+++ b/square/square.py
@@ -456,6 +456,10 @@ def make_plan(
         server, err = manio.download(k8s_config, k8s_client, selectors)
         assert not err and server is not None
 
+        # Align non-plannable fields, like the ServiceAccount tokens.
+        local_meta, err = manio.align_serviceaccount(local_meta, server)
+        assert not err
+
         # Create deployment plan.
         plan, err = compile_plan(k8s_config, local_meta, server)
         assert not err and plan

--- a/tests/support/k8s-serviceaccount.yaml
+++ b/tests/support/k8s-serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: "2019-12-06T17:35:31Z"
+  name: demoapp
+  namespace: default
+  resourceVersion: "12345678"
+  selfLink: /api/v1/namespaces/default/serviceaccounts/demoapp
+  uid: abcdefgh-1234-5678-abcd-efghjklmnopq
+secrets:
+- name: some-secret
+- name: demoapp-token-abcde
+- name: other-secret

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -636,8 +636,9 @@ class TestMainOptions:
 
     @mock.patch.object(manio, "load")
     @mock.patch.object(manio, "download")
+    @mock.patch.object(manio, "align_serviceaccount")
     @mock.patch.object(square, "compile_plan")
-    def test_make_plan(self, m_plan, m_down, m_load, kube_creds):
+    def test_make_plan(self, m_plan, m_align, m_down, m_load, kube_creds):
         """Basic test.
 
         This function does hardly anything to begin with, so we will merely
@@ -652,12 +653,13 @@ class TestMainOptions:
         m_load.return_value = ("local", None, False)
         m_down.return_value = ("server", False)
         m_plan.return_value = (plan, False)
+        m_align.side_effect = lambda loc_man, srv_man: (loc_man, False)
 
         # The arguments to the test function will always be the same in this test.
         selectors = Selectors(["kinds"], ["ns"], {("foo", "bar"), ("x", "y")})
         args = "kubeconf", "kubectx", "folder", selectors
 
-        # A successfull DIFF only computes and prints the plan.
+        # A successful DIFF only computes and prints the plan.
         plan, err = square.make_plan(*args)
         assert not err and isinstance(plan, DeploymentPlan)
         m_load.assert_called_once_with("folder", selectors)


### PR DESCRIPTION
Make it easier to use service accounts.

The PR adds `align_serviceaccounts`. This function will copy the `ServiceAccount` token secret from the cluster manifests into the local manifests before createing the `plan`. The change is in-memory only. No local files will be modified.