### PR TITLE
Improve resource schemas

### DIFF
--- a/square/schemas.py
+++ b/square/schemas.py
@@ -52,6 +52,7 @@ EXCLUSION_SCHEMA: Dict[str, Dict[str, Dict[Any, Any]]] = {
     "1.9": schema_1_9,
     "1.10": schema_1_9,
     "1.11": schema_1_9,
+    "1.12": schema_1_9,
     "1.13": schema_1_9,
     "1.14": schema_1_9,
 }

--- a/square/square.py
+++ b/square/square.py
@@ -36,8 +36,8 @@ def make_patch(
     """
     # Reduce local and server manifests to salient fields (ie apiVersion, kind,
     # metadata and spec). Abort on error.
-    loc, err1 = manio.strip(config, local)
-    srv, err2 = manio.strip(config, server)
+    (loc, _), err1 = manio.strip(config, local)
+    (srv, _), err2 = manio.strip(config, server)
     if err1 or err2 or loc is None or srv is None:
         return (None, True)
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,16 @@
+import square.schemas
+
+
+class TestMainGet:
+    def test_schemas_default(self):
+        """Manually verify one of the schemas that it has the default values."""
+        for version, schema in square.schemas.EXCLUSION_SCHEMA.items():
+            for data in schema.values():
+                assert data["metadata"]["uid"] is False
+
+    def test_populate_schemas(self):
+        exclude = {"1.10": {"TEST": {
+            "metadata": {"labels": "neither-bool-nor-dict"}
+        }}}
+
+        assert square.schemas.populate_schemas(exclude) is True

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -262,14 +262,6 @@ class TestPatchK8s:
             assert square.make_patch(config, loc, srv) == ((url, []), False)
 
             # Create two almost identical manifests, except the second one has
-            # the forbidden `metadata.namespace` attribute. This must fail.
-            loc = make_manifest(kind, None, name)
-            srv = copy.deepcopy(loc)
-            loc['metadata']['namespace'] = 'foo'
-            data, err = square.make_patch(config, loc, srv)
-            assert data is None and err is not None
-
-            # Create two almost identical manifests, except the second one has
             # different `metadata.labels`. This must succeed.
             loc = make_manifest(kind, None, name)
             srv = copy.deepcopy(loc)


### PR DESCRIPTION
Replace the old resource schema with a new one that uses exclusions only. Before, the schemas would have to define which fields were mandatory, which ones were disallowed, and which ones are optional.

This PR changes this to allow Square to manage everything except those explcitly defined in `square.schemas`.