### PR TITLE
Only support a single exclusion schema.

### DIFF
--- a/square/manio.py
+++ b/square/manio.py
@@ -608,12 +608,9 @@ def strip(
 
     # Verify the exclusion schema for the current resource and K8s version exist.
     try:
-        exclude = square.schemas.EXCLUSION_SCHEMA[config.version][manifest["kind"]]
+        exclude = square.schemas.EXCLUSION_SCHEMA[manifest["kind"]]
     except KeyError:
-        logit.error(
-            f"Unknown K8s version (<{config.version}>) "
-            f"or resource kind: <{kind}>"
-        )
+        logit.error(f"Unknown resource kind: <{kind}>")
         return ret_err
 
     # Sanity check the exclusion schema.

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,13 +4,9 @@ import square.schemas
 class TestMainGet:
     def test_schemas_default(self):
         """Manually verify one of the schemas that it has the default values."""
-        for version, schema in square.schemas.EXCLUSION_SCHEMA.items():
-            for data in schema.values():
-                assert data["metadata"]["uid"] is False
+        for data in square.schemas.EXCLUSION_SCHEMA.values():
+            assert data["metadata"]["uid"] is False
 
     def test_populate_schemas(self):
-        exclude = {"1.10": {"TEST": {
-            "metadata": {"labels": "neither-bool-nor-dict"}
-        }}}
-
+        exclude = {"TEST": {"metadata": {"labels": "neither-bool-nor-dict"}}}
         assert square.schemas.populate_schemas(exclude) is True


### PR DESCRIPTION
Only support a single exclusion schema, instead of individual schemas for each cluster.

This is in preparation for user defined exclusion schemas that are not hard coded into Square anymore.