### PR TITLE
K8sconfig fixture

### DIFF
--- a/square/manio.py
+++ b/square/manio.py
@@ -939,11 +939,11 @@ def download(
     for namespace in all_namespaces:
         for kind in selectors.kinds:
             try:
-                # Get the HTTP URL for the resource request.
+                # Get the K8s URL for the current resource kind.
                 url, err = square.k8s.urlpath(config, kind, namespace)
                 assert not err and url is not None
 
-                # Make HTTP request.
+                # Download the resource list from K8s.
                 manifest_list, err = square.k8s.get(client, url)
                 assert not err and manifest_list is not None
 

--- a/square/square.py
+++ b/square/square.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Iterable, Optional, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 import colorama
 import jsonpatch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import unittest.mock as mock
 
 import pytest
+import square.dtypes
 import square.square
 
 
@@ -15,3 +16,8 @@ def kube_creds(request):
     with mock.patch.object(square.k8s, "cluster_config") as m:
         m.return_value = (("k8s_config", "k8s_client"), False)
         yield m
+
+
+@pytest.fixture
+def k8sconfig():
+    yield square.dtypes.K8sConfig(version="1.10")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -187,7 +187,7 @@ class TestMain:
     @mock.patch.object(square, "get_resources")
     @mock.patch.object(square, "make_plan")
     @mock.patch.object(square, "apply_plan")
-    def test_main_nonzero_exit_on_error(self, m_apply, m_plan, m_get, m_k8s):
+    def test_main_nonzero_exit_on_error(self, m_apply, m_plan, m_get, m_k8s, k8sconfig):
         """Simulate sane program invocation.
 
         This test verifies that the bootstrapping works and the correct
@@ -196,13 +196,10 @@ class TestMain:
         `main.main` must return with a non-zero exit code.
 
         """
-        # Dummy configuration.
-        config = K8sConfig("url", "token", "ca_cert", "client_cert", "1.10", "")
-
         # Mock all calls to the K8s API.
-        m_k8s.load_auto_config.return_value = config
+        m_k8s.load_auto_config.return_value = k8sconfig
         m_k8s.session.return_value = "client"
-        m_k8s.version.return_value = (config, False)
+        m_k8s.version.return_value = (k8sconfig, False)
 
         # Pretend all main functions return errors.
         m_get.return_value = (None, True)


### PR DESCRIPTION
Use a proper fixture for `K8sConfig` in order to streamline the tests and simplify the next steps.