### PR TITLE
Improve consistency of `MetaManifest` information.

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -85,7 +85,7 @@ class MetaManifest(NamedTuple):
     """
     apiVersion: str
     kind: str
-    namespace: str
+    namespace: Optional[str]
     name: str
 
 

--- a/square/manio.py
+++ b/square/manio.py
@@ -30,7 +30,7 @@ def make_meta(manifest: dict) -> MetaManifest:
     """
     # Unpack the namespace. For Namespace resources, this will be the "name".
     if manifest["kind"] == "Namespace":
-        ns = manifest['metadata']['name']
+        ns = None
     else:
         # For non-Namespace manifests, the namespace may genuinely be None if
         # the resource applies globally, eg ClusterRole.
@@ -459,10 +459,11 @@ def filename_for_manifest(
     # "--groupby" command line option accepts. We will use this LUT below to
     # assemble the full manifest path.
     lut = {
-        # Get the namespace. Use "_global_" if the resource's namespace is
-        # `None`, which it will be for global resources like ClusterRole and
-        # ClusterRoleBinding.
-        "ns": meta.namespace or "_global_",
+        # Get the namespace. Use "_global_" for non-namespaced resources.
+        # The only exception are `Namespaces` themselves because it is neater
+        # to save their manifest in the relevant namespace folder, together
+        # with all the other resources that are in that namespace.
+        "ns": (meta.name if meta.kind == "Namespace" else None) or meta.namespace or "_global_",  # noqa
         "kind": meta.kind.lower(),
         # Try to find the user specified label. If the current resource lacks
         # that label then put it into the catchall file.

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -43,7 +43,7 @@ class TestHelpers:
         expected = MetaManifest(
             apiVersion=manifest["apiVersion"],
             kind=manifest["kind"],
-            namespace="name",
+            namespace=None,
             name=manifest["metadata"]["name"]
         )
         assert manio.make_meta(manifest) == expected


### PR DESCRIPTION
- The namespace of a `Namespace` resource is now `None`
- Declare `MetaManifest.namespace` as `Optional`, because it is.