### PR TITLE
Uniform interface into toplevel functions

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -156,14 +156,12 @@ class GroupBy(NamedTuple):
 
 class Commandline(NamedTuple):
     """Convenience structure for `main.py` - not used internally."""
-    command: str
     folder: Filepath
-    selectors: Selectors
     groupby: GroupBy
+    kube_ctx: Optional[str]
     kubeconfig: Filepath
     priorities: Collection[str]
-    kube_ctx: Optional[str] = None
-    verbosity: int = 0
+    selectors: Selectors
 
 
 # -----------------------------------------------------------------------------

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -155,12 +155,23 @@ class GroupBy(NamedTuple):
 
 
 class Config(NamedTuple):
-    """Convenience structure for `main.py` - not used internally."""
+    """Uniform interface into top level Square API."""
+    # Path to local manifests eg "./foo"
     folder: Filepath
+
+    # Specify relationship between new manifests and file names.
     groupby: GroupBy
+
+    # Kubernetes context (use `None` to use the default).
     kube_ctx: Optional[str]
+
+    # Path to Kubernetes credentials.
     kubeconfig: Filepath
+
+    # Sort the manifest in this order, or alphabetically at the end if not in the list.
     priorities: Collection[str]
+
+    # Only operate on resources that match the selectors.
     selectors: Selectors
 
 

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -154,7 +154,7 @@ class GroupBy(NamedTuple):
     order: Iterable[str]        # ["ns", "label=app", kind"]
 
 
-class Commandline(NamedTuple):
+class Config(NamedTuple):
     """Convenience structure for `main.py` - not used internally."""
     folder: Filepath
     groupby: GroupBy

--- a/square/main.py
+++ b/square/main.py
@@ -338,7 +338,7 @@ def main() -> int:
     if param.parser == "get":
         err = square.square.get_resources(cfg)
     elif param.parser == "plan":
-        plan, err = square.square.make_plan(*common_args)
+        plan, err = square.square.make_plan(cfg)
         square.square.show_plan(plan)
     elif param.parser == "apply":
         err = apply_plan(*common_args, "yes")

--- a/square/main.py
+++ b/square/main.py
@@ -162,8 +162,6 @@ def compile_config(cmdline_param) -> Tuple[Commandline, bool]:
 
     """
     err_resp = Commandline(
-        command="",
-        verbosity=0,
         folder=Filepath(""),
         kubeconfig=Filepath(""),
         kube_ctx=None,
@@ -232,8 +230,6 @@ def compile_config(cmdline_param) -> Tuple[Commandline, bool]:
     # Assemble the full configuration and return it.
     # -------------------------------------------------------------------------
     cfg = Commandline(
-        command=p.parser,
-        verbosity=p.verbosity,
         folder=folder,
         kubeconfig=kubeconfig,
         kube_ctx=p.ctx,
@@ -341,15 +337,15 @@ def main() -> int:
 
     # Do what the user asked us to do.
     common_args = Filepath(cfg.kubeconfig), cfg.kube_ctx, cfg.folder, cfg.selectors
-    if cfg.command == "get":
+    if param.parser == "get":
         err = square.square.get_resources(*common_args, cfg.groupby, cfg.priorities)
-    elif cfg.command == "plan":
+    elif param.parser == "plan":
         plan, err = square.square.make_plan(*common_args)
         square.square.show_plan(plan)
-    elif cfg.command == "apply":
+    elif param.parser == "apply":
         err = apply_plan(*common_args, "yes")
     else:
-        logit.error(f"Unknown command <{cfg.command}>")
+        logit.error(f"Unknown command <{param.parser}>")
         return 1
 
     # Return error code.

--- a/square/main.py
+++ b/square/main.py
@@ -336,7 +336,7 @@ def main() -> int:
     # Do what the user asked us to do.
     common_args = Filepath(cfg.kubeconfig), cfg.kube_ctx, cfg.folder, cfg.selectors
     if param.parser == "get":
-        err = square.square.get_resources(*common_args, cfg.groupby, cfg.priorities)
+        err = square.square.get_resources(cfg)
     elif param.parser == "plan":
         plan, err = square.square.make_plan(*common_args)
         square.square.show_plan(plan)

--- a/square/main.py
+++ b/square/main.py
@@ -272,7 +272,7 @@ def apply_plan(cfg: Config, confirm_string: Optional[str]) -> bool:
         print()
 
         # Apply the plan.
-        assert not square.square.apply_plan(cfg.kubeconfig, cfg.kube_ctx, plan)
+        assert not square.square.apply_plan(cfg, plan)
     except AssertionError:
         return True
 

--- a/square/main.py
+++ b/square/main.py
@@ -11,9 +11,7 @@ import colorama
 import square
 import square.square
 from square import __version__
-from square.dtypes import (
-    SUPPORTED_KINDS, Commandline, Filepath, GroupBy, Selectors,
-)
+from square.dtypes import SUPPORTED_KINDS, Config, Filepath, GroupBy, Selectors
 
 # Convenience: global logger instance to avoid repetitive code.
 logit = logging.getLogger("square")
@@ -151,17 +149,17 @@ def user_confirmed(answer: Optional[str] = "yes") -> bool:
         return False
 
 
-def compile_config(cmdline_param) -> Tuple[Commandline, bool]:
-    """Return `Commandline` from `cmdline_param`.
+def compile_config(cmdline_param) -> Tuple[Config, bool]:
+    """Return `Config` from `cmdline_param`.
 
     Inputs:
         cmdline_param: SimpleNamespace
 
     Returns:
-        Commandline, err
+        Config, err
 
     """
-    err_resp = Commandline(
+    err_resp = Config(
         folder=Filepath(""),
         kubeconfig=Filepath(""),
         kube_ctx=None,
@@ -229,7 +227,7 @@ def compile_config(cmdline_param) -> Tuple[Commandline, bool]:
     # -------------------------------------------------------------------------
     # Assemble the full configuration and return it.
     # -------------------------------------------------------------------------
-    cfg = Commandline(
+    cfg = Config(
         folder=folder,
         kubeconfig=kubeconfig,
         kube_ctx=p.ctx,
@@ -295,7 +293,7 @@ def apply_plan(
     return False
 
 
-def sanitise_resource_kinds(cfg: Commandline) -> Tuple[Commandline, bool]:
+def sanitise_resource_kinds(cfg: Config) -> Tuple[Config, bool]:
     """Populate the `Selector.kinds` with what the use specified on the commandline."""
     # Create a K8sConfig instance because it will contain all the info we need.
     k8sconfig, k8s_client, err = square.k8s.cluster_config(cfg.kubeconfig, cfg.kube_ctx)

--- a/square/square.py
+++ b/square/square.py
@@ -531,16 +531,16 @@ def get_resources(cfg: Config) -> bool:
                                    namespaces=None)
 
         # Load manifests from local files.
-        _, local_files, err = manio.load(cfg.folder, load_selectors)
-        assert not err and local_files is not None
+        _, local, err = manio.load(cfg.folder, load_selectors)
+        assert not err
 
         # Download manifests from K8s.
         server, err = manio.download(k8s_config, k8s_client, cfg.selectors)
-        assert not err and server is not None
+        assert not err
 
         # Sync the server manifests into the local manifests. All this happens in
         # memory and no files will be modified here - see `manio.save` in the next step.
-        synced_manifests, err = manio.sync(local_files, server, cfg.selectors,
+        synced_manifests, err = manio.sync(local, server, cfg.selectors,
                                            cfg.groupby, k8s_config.kinds)
         assert not err and synced_manifests
 

--- a/square/square.py
+++ b/square/square.py
@@ -460,27 +460,8 @@ def apply_plan(
     return False
 
 
-def make_plan(
-        kubeconfig: Filepath,
-        kube_ctx: Optional[str],
-        folder: Filepath,
-        selectors: Selectors,
-) -> Tuple[DeploymentPlan, bool]:
-    """Print the diff between `local_manifests` and `server_manifests`.
-
-    The diff shows what would have to change on the K8s server in order for it
-    to match the setup defined in `local_manifests`.
-
-    Inputs:
-        kubeconfig: Filepath
-            Path to Kubernetes credentials.
-        kubectx: str
-            Kubernetes context (use `None` to use the default).
-        client: `requests` session with correct K8s certificates.
-        folder: Path
-            Path to local manifests eg "./foo"
-        selectors: Selectors
-            Only operate on resources that match the selectors.
+def make_plan(cfg: Config) -> Tuple[DeploymentPlan, bool]:
+    """Return the deployment plan.
 
     Returns:
         Deployment plan.
@@ -488,15 +469,15 @@ def make_plan(
     """
     try:
         # Create properly configured Requests session to talk to K8s API.
-        k8s_config, k8s_client, err = k8s.cluster_config(kubeconfig, kube_ctx)
+        k8s_config, k8s_client, err = k8s.cluster_config(cfg.kubeconfig, cfg.kube_ctx)
         assert not err
 
         # Load manifests from local files.
-        local, _, err = manio.load(folder, selectors)
+        local, _, err = manio.load(cfg.folder, cfg.selectors)
         assert not err
 
         # Download manifests from K8s.
-        server, err = manio.download(k8s_config, k8s_client, selectors)
+        server, err = manio.download(k8s_config, k8s_client, cfg.selectors)
         assert not err
 
         # Align non-plannable fields, like the ServiceAccount tokens.

--- a/square/square.py
+++ b/square/square.py
@@ -412,15 +412,11 @@ def setup_logging(log_level: int) -> None:
     logit.info(f"Set log level to {level}")
 
 
-def apply_plan(
-        kubeconfig: Filepath,
-        kube_ctx: Optional[str],
-        plan: DeploymentPlan) -> bool:
+def apply_plan(cfg: Config, plan: DeploymentPlan) -> bool:
     """Update K8s resources according to the `plan`.
 
     Inputs:
-        kubeconfig: Filepath,
-        kube_ctx: Optional[str],
+        cfg: Square configuration.
         plan: DeploymentPlan
 
     Returns:
@@ -429,7 +425,7 @@ def apply_plan(
     """
     try:
         # Create properly configured Requests session to talk to K8s API.
-        k8s_config, k8s_client, err = k8s.cluster_config(kubeconfig, kube_ctx)
+        k8s_config, k8s_client, err = k8s.cluster_config(cfg.kubeconfig, cfg.kube_ctx)
         assert not err and k8s_config and k8s_client
 
         # Create the missing resources.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import unittest.mock as mock
 import pytest
 import square.dtypes
 import square.square
-from square.dtypes import Commandline, GroupBy, Selectors
+from square.dtypes import Config, GroupBy, Selectors
 
 from .test_helpers import k8s_apis
 
@@ -45,7 +45,7 @@ def config(k8sconfig, tmp_path):
     kubeconf = (tmp_path / "kubeconf")
     kubeconf.write_text("")
 
-    cfg = Commandline(
+    cfg = Config(
         folder=tmp_path,
         kubeconfig=kubeconf,
         kube_ctx=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,13 +27,17 @@ def k8sconfig():
     # K8s v1.15.
     cfg = square.dtypes.K8sConfig(version="1.15")
 
-    # Update the API endpoints.
+    # The set of API endpoints we can use in the tests.
     cfg.apis.clear()
     cfg.apis.update(k8s_apis(cfg))
+
+    # Manually insert common short spellings.
     cfg.short2kind["deployment"] = "Deployment"
     cfg.short2kind["service"] = "Service"
     cfg.short2kind["svc"] = "Service"
     cfg.short2kind["secret"] = "Secret"
+
+    # The set of canonical K8s resources we support.
     cfg.kinds.update({_ for _ in cfg.short2kind.values()})
 
     # Pass the fixture to the test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import unittest.mock as mock
 import pytest
 import square.dtypes
 import square.square
+from square.dtypes import Commandline, GroupBy, Selectors
 
 from .test_helpers import k8s_apis
 
@@ -36,4 +37,24 @@ def k8sconfig():
     cfg.kinds.update({_ for _ in cfg.short2kind.values()})
 
     # Pass the fixture to the test.
+    yield cfg
+
+
+@pytest.fixture
+def config(k8sconfig, tmp_path):
+    kubeconf = (tmp_path / "kubeconf")
+    kubeconf.write_text("")
+
+    cfg = Commandline(
+        folder=tmp_path,
+        kubeconfig=kubeconf,
+        kube_ctx=None,
+        selectors=Selectors(
+            kinds=set(k8sconfig.kinds),
+            namespaces=['default'],
+            labels={("app", "demo")},
+        ),
+        groupby=GroupBy("", tuple()),
+        priorities=("Namespace", "Secret", "Service", "Deployment"),
+    )
     yield cfg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import unittest.mock as mock
 import pytest
 import square.dtypes
 import square.square
-from square.dtypes import Config, GroupBy, Selectors
+from square.dtypes import SUPPORTED_KINDS, Config, GroupBy, Selectors
 
 from .test_helpers import k8s_apis
 
@@ -55,6 +55,6 @@ def config(k8sconfig, tmp_path):
             labels={("app", "demo")},
         ),
         groupby=GroupBy("", tuple()),
-        priorities=("Namespace", "Secret", "Service", "Deployment"),
+        priorities=SUPPORTED_KINDS
     )
     yield cfg

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,7 +235,15 @@ class TestMain:
         # Every main function must have been called exactly once.
         selectors = Selectors({"Deployment", "Service"}, None, set())
         args = fname_kubeconfig, None, pathlib.Path("myfolder"), selectors
-        m_get.assert_called_once_with(*args, groupby, SUPPORTED_KINDS)
+        cfg = Config(
+            folder=pathlib.Path("myfolder"),
+            groupby=groupby,
+            kube_ctx=None,
+            kubeconfig=fname_kubeconfig,
+            priorities=tuple(SUPPORTED_KINDS),
+            selectors=selectors,
+        )
+        m_get.assert_called_once_with(cfg)
         m_apply.assert_called_once_with(*args, "yes")
         m_plan.assert_called_once_with(*args)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -245,7 +245,7 @@ class TestMain:
         )
         m_get.assert_called_once_with(cfg)
         m_apply.assert_called_once_with(*args, "yes")
-        m_plan.assert_called_once_with(*args)
+        m_plan.assert_called_once_with(cfg)
 
     def test_main_version(self):
         """Simulate "version" command."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ import square.main as main
 import square.manio as manio
 import square.square as square
 from square.dtypes import (
-    SUPPORTED_KINDS, Commandline, DeltaCreate, DeltaDelete, DeltaPatch,
+    SUPPORTED_KINDS, Config, DeltaCreate, DeltaDelete, DeltaPatch,
     DeploymentPlan, Filepath, GroupBy, JsonPatch, Selectors,
 )
 
@@ -49,7 +49,7 @@ class TestResourceCleanup:
         m_cluster.side_effect = lambda *args: (k8sconfig, None, False)
 
         # Use specified a valid set of `selectors.kinds` using various spellings.
-        cfg = Commandline(
+        cfg = Config(
             folder=pathlib.Path('/tmp'),
             kubeconfig=None,
             kube_ctx=None,
@@ -75,7 +75,7 @@ class TestResourceCleanup:
 
     def test_sanitise_resource_kinds_err_config(self, k8sconfig):
         """Abort if the kubeconfig file does not exist."""
-        cfg = Commandline(
+        cfg = Config(
             folder=pathlib.Path('/tmp'),
             kubeconfig=Filepath("/does/not/exist"),
             kube_ctx=None,
@@ -97,7 +97,7 @@ class TestMain:
         """Compile various valid configurations."""
         param = dummy_command_param()
         cfg, err = main.compile_config(param)
-        assert not err and cfg == Commandline(
+        assert not err and cfg == Config(
             folder=pathlib.Path('/tmp'),
             kubeconfig=param.kubeconfig,
             kube_ctx=None,
@@ -137,7 +137,7 @@ class TestMain:
         param = dummy_command_param()
         param.kubeconfig /= "does-not-exist"
         assert main.compile_config(param) == (
-            Commandline(
+            Config(
                 folder=Filepath(""),
                 kubeconfig=Filepath(""),
                 kube_ctx=None,
@@ -150,7 +150,7 @@ class TestMain:
         """Parse file system hierarchy."""
         param = dummy_command_param()
 
-        err_resp = Commandline(
+        err_resp = Config(
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kube_ctx=None,
@@ -406,7 +406,7 @@ class TestMain:
             param = main.parse_commandline_args()
             assert param.groupby == ["ns", "label=foo", "label=bar"]
 
-        expected = Commandline(
+        expected = Config(
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kube_ctx=None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -524,12 +524,12 @@ class TestApplyPlan:
         # Function must apply the plan if the user confirms it.
         with mock.patch.object(main, 'input', lambda _: "yes"):
             assert fun(config, "yes") is False
-        m_apply.assert_called_once_with(config.kubeconfig, config.kube_ctx, plan)
+        m_apply.assert_called_once_with(config, plan)
 
         # Repeat with disabled security question.
         m_apply.reset_mock()
         assert fun(config, None) is False
-        m_apply.assert_called_once_with(config.kubeconfig, config.kube_ctx, plan)
+        m_apply.assert_called_once_with(config, plan)
 
         # -----------------------------------------------------------------
         #                   Simulate An Empty Plan

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,8 +50,6 @@ class TestResourceCleanup:
 
         # Use specified a valid set of `selectors.kinds` using various spellings.
         cfg = Commandline(
-            command='get',
-            verbosity=9,
             folder=pathlib.Path('/tmp'),
             kubeconfig=None,
             kube_ctx=None,
@@ -78,8 +76,6 @@ class TestResourceCleanup:
     def test_sanitise_resource_kinds_err_config(self, k8sconfig):
         """Abort if the kubeconfig file does not exist."""
         cfg = Commandline(
-            command='get',
-            verbosity=9,
             folder=pathlib.Path('/tmp'),
             kubeconfig=Filepath("/does/not/exist"),
             kube_ctx=None,
@@ -102,8 +98,6 @@ class TestMain:
         param = dummy_command_param()
         cfg, err = main.compile_config(param)
         assert not err and cfg == Commandline(
-            command='get',
-            verbosity=9,
             folder=pathlib.Path('/tmp'),
             kubeconfig=param.kubeconfig,
             kube_ctx=None,
@@ -144,8 +138,6 @@ class TestMain:
         param.kubeconfig /= "does-not-exist"
         assert main.compile_config(param) == (
             Commandline(
-                command="",
-                verbosity=0,
                 folder=Filepath(""),
                 kubeconfig=Filepath(""),
                 kube_ctx=None,
@@ -159,8 +151,6 @@ class TestMain:
         param = dummy_command_param()
 
         err_resp = Commandline(
-            command="",
-            verbosity=0,
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kube_ctx=None,
@@ -417,8 +407,6 @@ class TestMain:
             assert param.groupby == ["ns", "label=foo", "label=bar"]
 
         expected = Commandline(
-            command="",
-            verbosity=0,
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kube_ctx=None,

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,19 +1,16 @@
 import copy
-import os
-import random
 import unittest.mock as mock
 
-import pytest
 import square.k8s as k8s
 import square.manio as manio
 import square.square as square
 from square.dtypes import (
-    DeltaCreate, DeltaDelete, DeltaPatch, DeploymentPlan, GroupBy, JsonPatch,
-    K8sConfig, MetaManifest, Selectors,
+    DeltaCreate, DeltaDelete, DeltaPatch, DeploymentPlan, JsonPatch, K8sConfig,
+    MetaManifest, Selectors,
 )
 from square.k8s import resource
 
-from .test_helpers import make_manifest, mk_deploy
+from .test_helpers import make_manifest
 
 
 class TestLogging:

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -604,7 +604,7 @@ class TestMainOptions:
     @mock.patch.object(k8s, "post")
     @mock.patch.object(k8s, "patch")
     @mock.patch.object(k8s, "delete")
-    def test_apply_plan(self, m_delete, m_apply, m_post, kube_creds):
+    def test_apply_plan(self, m_delete, m_apply, m_post, config, kube_creds):
         """Simulate a successful resource update (add, patch delete).
 
         To this end, create a valid (mocked) deployment plan, mock out all
@@ -645,7 +645,7 @@ class TestMainOptions:
         # Update the K8s resources and verify that the test functions made the
         # corresponding calls to K8s.
         reset_mocks()
-        assert square.apply_plan("kubeconfig", "kubectx", plan) is False
+        assert square.apply_plan(config, plan) is False
         m_post.assert_called_once_with("k8s_client", "create_url", "create_man")
         m_apply.assert_called_once_with("k8s_client", patch.url, patch.ops)
         m_delete.assert_called_once_with("k8s_client", "delete_url", "delete_man")
@@ -660,7 +660,7 @@ class TestMainOptions:
 
         # Call test function and verify that it did not try to apply
         # the empty plan.
-        assert square.apply_plan("kubeconfig", "kubectx", empty_plan) is False
+        assert square.apply_plan(config, empty_plan) is False
         assert not m_post.called
         assert not m_apply.called
         assert not m_delete.called
@@ -672,15 +672,15 @@ class TestMainOptions:
 
         # Make `delete` fail.
         m_delete.return_value = (None, True)
-        assert square.apply_plan("kubeconfig", "kubectx", plan) is True
+        assert square.apply_plan(config, plan) is True
 
         # Make `patch` fail.
         m_apply.return_value = (None, True)
-        assert square.apply_plan("kubeconfig", "kubectx", plan) is True
+        assert square.apply_plan(config, plan) is True
 
         # Make `post` fail.
         m_post.return_value = (None, True)
-        assert square.apply_plan("kubeconfig", "kubectx", plan) is True
+        assert square.apply_plan(config, plan) is True
 
     @mock.patch.object(manio, "load")
     @mock.patch.object(manio, "download")


### PR DESCRIPTION
Define a uniform `Config` interface that all top level functions of Square expect.

This will streamline the API and also make it easier to augment the parameters list in the future.

There are no changes to the behavior of Square.