### PR TITLE
Sane defaults

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -162,20 +162,22 @@ class Config(NamedTuple):
     # Path to local manifests eg "./foo"
     folder: Filepath
 
-    # Specify relationship between new manifests and file names.
-    groupby: GroupBy
+    # Path to Kubernetes credentials.
+    kubeconfig: Filepath
 
     # Kubernetes context (use `None` to use the default).
     kube_ctx: Optional[str]
 
-    # Path to Kubernetes credentials.
-    kubeconfig: Filepath
+    # Only operate on resources that match the selectors.
+    selectors: Selectors = Selectors(kinds=set(DEFAULT_PRIORITIES),
+                                     namespaces=None,
+                                     labels=set())
 
     # Sort the manifest in this order, or alphabetically at the end if not in the list.
-    priorities: Collection[str]
+    priorities: Collection[str] = tuple(DEFAULT_PRIORITIES)
 
-    # Only operate on resources that match the selectors.
-    selectors: Selectors
+    # How to structure the folder directory when syncing manifests.
+    groupby: GroupBy = GroupBy("", tuple())
 
 
 # -----------------------------------------------------------------------------

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -5,7 +5,7 @@ from typing import (
 
 # We support these resource types. The order matters because it determines the
 # order in which the manifests will be grouped in the output files.
-SUPPORTED_KINDS = (
+DEFAULT_PRIORITIES = (
     # Namespaces must come first to ensure the other resources can be created
     # within them.
     "Namespace",

--- a/square/main.py
+++ b/square/main.py
@@ -11,7 +11,9 @@ import colorama
 import square
 import square.square
 from square import __version__
-from square.dtypes import SUPPORTED_KINDS, Config, Filepath, GroupBy, Selectors
+from square.dtypes import (
+    DEFAULT_PRIORITIES, Config, Filepath, GroupBy, Selectors,
+)
 
 # Convenience: global logger instance to avoid repetitive code.
 logit = logging.getLogger("square")
@@ -61,7 +63,7 @@ def parse_commandline_args():
     )
     parent.add_argument(
         "-p", "--priorities", nargs="*",
-        metavar="priorities", dest="priorities", default=tuple(SUPPORTED_KINDS),
+        metavar="priorities", dest="priorities", default=tuple(DEFAULT_PRIORITIES),
         help="Sort resource in this order when saving and applying",
     )
     parent.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import unittest.mock as mock
 import pytest
 import square.dtypes
 import square.square
-from square.dtypes import SUPPORTED_KINDS, Config, GroupBy, Selectors
+from square.dtypes import DEFAULT_PRIORITIES, Config, GroupBy, Selectors
 
 from .test_helpers import k8s_apis
 
@@ -59,6 +59,6 @@ def config(k8sconfig, tmp_path):
             labels={("app", "demo")},
         ),
         groupby=GroupBy("", tuple()),
-        priorities=SUPPORTED_KINDS
+        priorities=DEFAULT_PRIORITIES
     )
     yield cfg

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ import square.main as main
 import square.manio as manio
 import square.square as square
 from square.dtypes import (
-    SUPPORTED_KINDS, Config, DeltaCreate, DeltaDelete, DeltaPatch,
+    DEFAULT_PRIORITIES, Config, DeltaCreate, DeltaDelete, DeltaPatch,
     DeploymentPlan, Filepath, GroupBy, JsonPatch, Selectors,
 )
 
@@ -323,7 +323,7 @@ class TestMain:
         # User did not specify a priority.
         with mock.patch("sys.argv", args):
             ret = main.parse_commandline_args()
-            assert ret.priorities == SUPPORTED_KINDS
+            assert ret.priorities == DEFAULT_PRIORITIES
 
         # User did specify priorities.
         with mock.patch("sys.argv", args + ["--priorities", "foo", "bar"]):

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -5,8 +5,8 @@ import square.k8s as k8s
 import square.manio as manio
 import square.square as square
 from square.dtypes import (
-    DeltaCreate, DeltaDelete, DeltaPatch, DeploymentPlan, JsonPatch, K8sConfig,
-    MetaManifest, Selectors,
+    DEFAULT_PRIORITIES, Config, DeltaCreate, DeltaDelete, DeltaPatch,
+    DeploymentPlan, GroupBy, JsonPatch, K8sConfig, MetaManifest, Selectors,
 )
 from square.k8s import resource
 
@@ -23,6 +23,19 @@ class TestLogging:
 
 
 class TestBasic:
+    def test_config_default(self, tmp_path):
+        """Default values for Config."""
+        assert Config(folder=tmp_path, kubeconfig=tmp_path, kube_ctx="ctx") == Config(
+            folder=tmp_path,
+            kube_ctx="ctx",
+            kubeconfig=tmp_path,
+            selectors=Selectors(kinds=set(DEFAULT_PRIORITIES),
+                                namespaces=None,
+                                labels=set()),
+            priorities=DEFAULT_PRIORITIES,
+            groupby=GroupBy("", tuple()),
+        )
+
     def test_find_namespace_orphans(self):
         """Return all resource manifests that belong to non-existing
         namespaces.


### PR DESCRIPTION
- Rename `dtypes.SUPPORTED_KINDS` to `dtypes.DEFAULT_PRIORITIES`.
- Populate `dtypes.Config` with sensible defaults for all non-critical fields.