### PR TITLE
Add exclusion schemas to config

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -179,6 +179,9 @@ class Config(NamedTuple):
     # How to structure the folder directory when syncing manifests.
     groupby: GroupBy = GroupBy("", tuple())
 
+    # Define which fields to skip for which resource.
+    filters: dict = {}
+
 
 # -----------------------------------------------------------------------------
 #                                 Miscellaneous

--- a/square/manio.py
+++ b/square/manio.py
@@ -436,8 +436,8 @@ def diff(config: Config,
     """
     # Clean up the input manifests because we do not want to diff, for instance,
     # the `status` fields.
-    (srv, _), err1 = strip(k8sconfig, server, square.schemas.EXCLUSION_SCHEMA)
-    (loc, _), err2 = strip(k8sconfig, local, square.schemas.EXCLUSION_SCHEMA)
+    (srv, _), err1 = strip(k8sconfig, server, config.filters)
+    (loc, _), err2 = strip(k8sconfig, local, config.filters)
     if err1 or err2:
         return ("", True)
 
@@ -943,7 +943,7 @@ def download(config: Config, k8sconfig: K8sConfig) -> Tuple[ServerManifests, boo
                 assert not err and manifests is not None
 
                 # Drop all manifest fields except "apiVersion", "metadata" and "spec".
-                ret = {k: strip(k8sconfig, man, square.schemas.EXCLUSION_SCHEMA)
+                ret = {k: strip(k8sconfig, man, config.filters)
                        for k, man in manifests.items()}
 
                 # Ensure `strip` worked for every manifest.

--- a/square/schemas.py
+++ b/square/schemas.py
@@ -13,23 +13,6 @@ from typing import Any, Dict, Union
 logit = logging.getLogger("square")
 
 
-EXCLUSION_SCHEMA: Dict[str, dict] = {
-    "ConfigMap": {
-        "metadata": {"annotations": {
-            "control-plane.alpha.kubernetes.io/leader": False,
-        }}
-    },
-    "HorizontalPodAutoscaler": {
-        "metadata": {"annotations": {
-            "control-plane.alpha.kubernetes.io/leader": False,
-            "autoscaling.alpha.kubernetes.io/conditions": False,
-            "autoscaling.alpha.kubernetes.io/current-metrics": False,
-        }}
-    },
-    "Service": {"spec": {"clusterIP": False, "sessionAffinity": False}},
-}
-
-
 def _is_exclusion_sane(schema: Dict[str, Union[dict, bool]]) -> bool:
     """Return `True` iff `schema` is valid."""
     # Iterate over all fields of all K8s resource type.
@@ -88,7 +71,3 @@ def populate_schemas(schemas: Dict[str, Dict[Any, Any]]) -> bool:
             logit.error(f"ERROR - Exclusion schema for <{resource_kind}> is invalid")
             return True
     return False
-
-
-# Finalise the exclusion schemas and sanity check them.
-assert populate_schemas(EXCLUSION_SCHEMA) is False

--- a/square/square.py
+++ b/square/square.py
@@ -40,8 +40,8 @@ def make_patch(
     """
     # Reduce local and server manifests to salient fields (ie apiVersion, kind,
     # metadata and spec). Abort on error.
-    (loc, _), err1 = manio.strip(k8sconfig, local, square.schemas.EXCLUSION_SCHEMA)
-    (srv, _), err2 = manio.strip(k8sconfig, server, square.schemas.EXCLUSION_SCHEMA)
+    (loc, _), err1 = manio.strip(k8sconfig, local, config.filters)
+    (srv, _), err2 = manio.strip(k8sconfig, server, config.filters)
     if err1 or err2 or loc is None or srv is None:
         return (JsonPatch("", []), True)
 

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -6,7 +6,6 @@ import unittest.mock as mock
 import square.dotdict as dotdict
 import square.k8s as k8s
 import square.manio as manio
-import square.schemas
 import yaml
 from square.dtypes import Filepath, GroupBy, MetaManifest, Selectors
 from square.k8s import resource
@@ -819,7 +818,7 @@ class TestManifestValidation:
 
     def test_strip_namespace(self, k8sconfig):
         """Filter NAMESPACE manifests."""
-        exclude = square.schemas.EXCLUSION_SCHEMA
+        exclude = {}
 
         # Valid: a namespace manifest without a `metadata.namespace` field.
         manifest = {
@@ -848,7 +847,7 @@ class TestManifestValidation:
 
     def test_strip_deployment(self, k8sconfig):
         """Filter DEPLOYMENT manifests."""
-        exclude = square.schemas.EXCLUSION_SCHEMA
+        exclude = {}
 
         # A valid service manifest with a few optional and irrelevant keys.
         manifest = {
@@ -1742,7 +1741,7 @@ class TestDownloadManifests:
         The test only mocks the K8s API call. All other functions actually run.
 
         """
-        exclude = square.schemas.EXCLUSION_SCHEMA
+        exclude = {}
         make_meta = manio.make_meta
 
         meta = [

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,11 +2,6 @@ import square.schemas
 
 
 class TestMainGet:
-    def test_schemas_default(self):
-        """Manually verify one of the schemas that it has the default values."""
-        for data in square.schemas.EXCLUSION_SCHEMA.values():
-            assert data["metadata"]["uid"] is False
-
     def test_populate_schemas(self):
         exclude = {"TEST": {"metadata": {"labels": "neither-bool-nor-dict"}}}
         assert square.schemas.populate_schemas(exclude) is True

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -34,6 +34,7 @@ class TestBasic:
                                 labels=set()),
             priorities=DEFAULT_PRIORITIES,
             groupby=GroupBy("", tuple()),
+            filters={},
         )
 
     def test_find_namespace_orphans(self):


### PR DESCRIPTION
- Add `Config.filters` key.
- Use that new key instead of the global `EXCLUSION_SCHEMA`.

This removes one of the last global structures that blocked further progress on Square.