### PR TITLE
Streamline datatypes

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,7 +1,6 @@
 import pathlib
 from typing import (
-    Any, Collection, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple,
-    Union,
+    Any, Collection, Dict, List, NamedTuple, Optional, Set, Tuple, Union,
 )
 
 from pydantic import BaseModel
@@ -152,15 +151,15 @@ class DeploymentPlanMeta(NamedTuple):
 # -----------------------------------------------------------------------------
 class Selectors(NamedTuple):
     """Comprises all the filters to select manifests."""
-    kinds: Set[str]
-    namespaces: Optional[Iterable[str]]
-    labels: Optional[Set[Tuple[str, str]]]
+    kinds: Set[str] = set(DEFAULT_PRIORITIES)
+    namespaces: Optional[List[str]] = None
+    labels: Optional[Set[Tuple[str, str]]] = set()
 
 
 class GroupBy(NamedTuple):
     """Define how to organise downloaded manifest on the files system."""
-    label: str                  # "app"
-    order: Iterable[str]        # ["ns", "label=app", kind"]
+    label: str = ""             # "app"
+    order: List[str] = []       # ["ns", "label=app", kind"]
 
 
 class Config(NamedTuple):
@@ -175,15 +174,13 @@ class Config(NamedTuple):
     kube_ctx: Optional[str]
 
     # Only operate on resources that match the selectors.
-    selectors: Selectors = Selectors(kinds=set(DEFAULT_PRIORITIES),
-                                     namespaces=None,
-                                     labels=set())
+    selectors: Selectors = Selectors()
 
     # Sort the manifest in this order, or alphabetically at the end if not in the list.
-    priorities: Collection[str] = tuple(DEFAULT_PRIORITIES)
+    priorities: List[str] = list(DEFAULT_PRIORITIES)
 
     # How to structure the folder directory when syncing manifests.
-    groupby: GroupBy = GroupBy("", tuple())
+    groupby: GroupBy = GroupBy()
 
     # Define which fields to skip for which resource.
     filters: dict = {}

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -152,7 +152,7 @@ class DeploymentPlanMeta(NamedTuple):
 class Selectors(NamedTuple):
     """Comprises all the filters to select manifests."""
     kinds: Set[str] = set(DEFAULT_PRIORITIES)
-    namespaces: Optional[List[str]] = None
+    namespaces: List[str] = []
     labels: Optional[Set[Tuple[str, str]]] = set()
 
 

--- a/square/main.py
+++ b/square/main.py
@@ -169,8 +169,8 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         kubeconfig=Filepath(""),
         kube_ctx=None,
         selectors=Selectors(set(), None, None),
-        groupby=GroupBy("", tuple()),
-        priorities=tuple(),
+        groupby=GroupBy("", []),
+        priorities=[],
     ), True
 
     # Convenience.
@@ -226,7 +226,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         except (ValueError, AssertionError):
             logit.error(f"Invalid label specification <{labels[0]}>")
             return err_resp
-    groupby = GroupBy(order=tuple(clean_order), label=label_name)
+    groupby = GroupBy(order=list(clean_order), label=label_name)
     del order, clean_order, label_name
 
     # -------------------------------------------------------------------------

--- a/square/main.py
+++ b/square/main.py
@@ -168,7 +168,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         folder=Filepath(""),
         kubeconfig=Filepath(""),
         kube_ctx=None,
-        selectors=Selectors(set(), None, None),
+        selectors=Selectors(set(), [], None),
         groupby=GroupBy("", []),
         priorities=[],
     ), True

--- a/square/manio.py
+++ b/square/manio.py
@@ -99,7 +99,7 @@ def select(manifest: dict, selectors: Selectors) -> bool:
 
     # Include the resource if it is a) namespaced b) we have namespace
     # selectors and c) the resource matches one of them.
-    if ns and selectors.namespaces is not None and ns not in selectors.namespaces:
+    if ns and selectors.namespaces and ns not in selectors.namespaces:
         logit.debug(f"Namespace {ns} does not match selector {selectors.namespaces}")
         return False
 
@@ -922,7 +922,7 @@ def download(config: Config, k8sconfig: K8sConfig) -> Tuple[ServerManifests, boo
 
     # Ensure `namespaces` is always a list to avoid special casing below.
     all_namespaces: Iterable[Optional[str]]
-    if config.selectors.namespaces is None:
+    if not config.selectors.namespaces:
         all_namespaces = [None]
     else:
         all_namespaces = config.selectors.namespaces

--- a/square/square.py
+++ b/square/square.py
@@ -56,7 +56,7 @@ def load_config(fname: Filepath) -> Tuple[Config, bool]:
         filters=raw.filters,
         selectors=Selectors(
             kinds=set(raw.selectors.kinds),
-            namespaces=None or raw.selectors.namespaces,
+            namespaces=[] or raw.selectors.namespaces,
             labels={(kv.name, kv.value) for kv in raw.selectors.labels},
         )
     )
@@ -554,7 +554,7 @@ def get_resources(cfg: Config) -> bool:
         # at the end of this function, uses it).
         load_selectors = Selectors(kinds=k8sconfig.kinds,
                                    labels=None,
-                                   namespaces=None)
+                                   namespaces=[])
 
         # Load manifests from local files.
         _, local, err = manio.load(cfg.folder, load_selectors)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def config(k8sconfig, tmp_path):
             namespaces=['default'],
             labels={("app", "demo")},
         ),
-        groupby=GroupBy(label="", order=tuple()),
+        groupby=GroupBy(label="", order=[]),
         priorities=DEFAULT_PRIORITIES
     )
     yield cfg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def config(k8sconfig, tmp_path):
             namespaces=['default'],
             labels={("app", "demo")},
         ),
-        groupby=GroupBy("", tuple()),
+        groupby=GroupBy(label="", order=tuple()),
         priorities=DEFAULT_PRIORITIES
     )
     yield cfg

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -150,9 +150,9 @@ class TestMain:
                 folder=Filepath(""),
                 kubeconfig=Filepath(""),
                 kube_ctx=None,
-                selectors=Selectors(set(), None, None),
-                groupby=GroupBy("", tuple()),
-                priorities=tuple(),
+                selectors=Selectors(set(), [], None),
+                groupby=GroupBy("", []),
+                priorities=[],
             ), True)
 
     def test_compile_hierarchy_ok(self, config):
@@ -163,9 +163,9 @@ class TestMain:
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kube_ctx=None,
-            selectors=Selectors(set(), None, None),
-            groupby=GroupBy("", tuple()),
-            priorities=tuple(),
+            selectors=Selectors(set(), [], None),
+            groupby=GroupBy("", []),
+            priorities=[],
         ), True
 
         # ----------------------------------------------------------------------
@@ -175,7 +175,7 @@ class TestMain:
             param.parser = cmd
             ret, err = main.compile_config(param)
             assert not err
-            assert ret.groupby == GroupBy(order=tuple(), label="")
+            assert ret.groupby == GroupBy(label="", order=[])
             del cmd, ret, err
 
         # ----------------------------------------------------------------------
@@ -185,8 +185,7 @@ class TestMain:
         param.groupby = ("ns", "kind", "label=app", "ns")
         ret, err = main.compile_config(param)
         assert not err
-        assert ret.groupby == GroupBy(
-            order=("ns", "kind", "label", "ns"), label="app")
+        assert ret.groupby == GroupBy(label="app", order=["ns", "kind", "label", "ns"])
 
         # ----------------------------------------------------------------------
         # User defined hierarchy with invalid labels.
@@ -373,7 +372,7 @@ class TestMain:
 
         cfg, err = main.compile_config(param)
         assert not err
-        assert cfg.groupby == GroupBy(label="", order=tuple())
+        assert cfg.groupby == GroupBy(label="", order=[])
 
         # ----------------------------------------------------------------------
         # User defined file system hierarchy.
@@ -385,7 +384,7 @@ class TestMain:
 
         cfg, err = main.compile_config(param)
         assert not err
-        assert cfg.groupby == GroupBy(label="", order=("ns", "kind"))
+        assert cfg.groupby == GroupBy(label="", order=["ns", "kind"])
 
         # ----------------------------------------------------------------------
         # Include a label into the hierarchy and use "ns" twice.
@@ -397,7 +396,7 @@ class TestMain:
 
         cfg, err = main.compile_config(param)
         assert not err
-        assert cfg.groupby == GroupBy(label="foo", order=("ns", "label", "ns"))
+        assert cfg.groupby == GroupBy(label="foo", order=["ns", "label", "ns"])
 
         # ----------------------------------------------------------------------
         # The label resource, unlike "ns" or "kind", can only be specified
@@ -412,9 +411,9 @@ class TestMain:
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kube_ctx=None,
-            selectors=Selectors(set(), None, None),
-            groupby=GroupBy("", tuple()),
-            priorities=tuple(),
+            selectors=Selectors(set(), [], None),
+            groupby=GroupBy("", []),
+            priorities=[],
         )
         assert main.compile_config(param) == (expected, True)
 

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -668,7 +668,7 @@ class TestYamlManifestIO:
         # :: Dict[MetaManifests:YamlDict] -> Dict[Filename:List[(MetaManifest, YamlDict)]]
         updated_manifests, err = manio.sync(
             fdata_meta, server_manifests,
-            Selectors({"Deployment"}, namespaces=None, labels=None),
+            Selectors({"Deployment"}, namespaces=[], labels=None),
             groupby,
         )
         assert err is False
@@ -1377,17 +1377,13 @@ class TestSync:
         }
 
         # ----------------------------------------------------------------------
-        # Special cases: empty list of namespaces and/or resources.
-        # Must do nothing.
+        # Special cases: empty list of resources. Must do nothing.
         # ----------------------------------------------------------------------
         expected = loc_man
-        selectors = Selectors(set(), namespaces=None, labels=None)
-        assert fun(loc_man, srv_man, selectors, groupby) == (expected, False)
-
         selectors = Selectors(set(), namespaces=[], labels=None)
         assert fun(loc_man, srv_man, selectors, groupby) == (expected, False)
 
-        selectors = Selectors({"Deployment", "Service"}, namespaces=[], labels=None)
+        selectors = Selectors(set(), namespaces=[], labels=None)
         assert fun(loc_man, srv_man, selectors, groupby) == (expected, False)
 
         # NOTE: this must *not* sync the Namespace manifest from "ns1" because
@@ -1414,7 +1410,7 @@ class TestSync:
             kinds = set(kinds)
 
             # Implicitly use all namespaces.
-            selectors = Selectors(kinds, namespaces=None, labels=None)
+            selectors = Selectors(kinds, namespaces=[], labels=None)
             assert fun(loc_man, srv_man, selectors, groupby) == expected
 
             # Specify all namespaces explicitly.
@@ -1453,7 +1449,7 @@ class TestSync:
                 (svc_ns1, svc_ns1_man),
             ],
         }, False
-        selectors = Selectors({"Deployment"}, namespaces=None, labels=None)
+        selectors = Selectors({"Deployment"}, namespaces=[], labels=None)
         assert fun(loc_man, srv_man, selectors, groupby) == expected
 
         # ----------------------------------------------------------------------
@@ -1646,7 +1642,7 @@ class TestSync:
 
         """
         # Valid selector for Deployment manifests.
-        selectors = Selectors({"Deployment"}, namespaces=None, labels=None)
+        selectors = Selectors({"Deployment"}, namespaces=[], labels=None)
 
         # Simulate the scenario where the server has a Deployment we lack
         # locally. This will ensure that `sync` will try to create a new file
@@ -1666,7 +1662,7 @@ class TestSync:
         Some other tests, most notably those for the `align` function, rely on this.
         """
         # Fixtures.
-        selectors = Selectors({"ServiceAccount"}, namespaces=None, labels=None)
+        selectors = Selectors({"ServiceAccount"}, namespaces=[], labels=None)
         name = 'demoapp'
 
         # Load the test support file and ensure it contains exactly one manifest.
@@ -1695,7 +1691,7 @@ class TestSync:
 
         """
         # Fixtures.
-        selectors = Selectors({"ServiceAccount"}, namespaces=None, labels=None)
+        selectors = Selectors({"ServiceAccount"}, namespaces=[], labels=None)
 
         # Load and unpack the ServiceAccount manifest. Make two copies so we
         # can create local/cluster manifest as inputs for the `align` function.
@@ -1854,7 +1850,7 @@ class TestDownloadManifests:
         l_dply_1 = {'apiVersion': 'apps/v1', 'kind': 'DeploymentList', "items": [meta[3]]}
 
         # ----------------------------------------------------------------------
-        # Request resources from all namespaces implicitly via namespaces=None
+        # Request resources from all namespaces implicitly via namespaces=[]
         # Must make two calls: one for each kind ("Deployment", "Namespace").
         # Must silently ignore the "Unknown" resource.
         # ----------------------------------------------------------------------

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -33,8 +33,8 @@ class TestBasic:
             selectors=Selectors(kinds=set(DEFAULT_PRIORITIES),
                                 namespaces=None,
                                 labels=set()),
-            priorities=DEFAULT_PRIORITIES,
-            groupby=GroupBy("", tuple()),
+            priorities=list(DEFAULT_PRIORITIES),
+            groupby=GroupBy(label="", order=[]),
             filters={},
         )
 

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -31,7 +31,7 @@ class TestBasic:
             kube_ctx="ctx",
             kubeconfig=tmp_path,
             selectors=Selectors(kinds=set(DEFAULT_PRIORITIES),
-                                namespaces=None,
+                                namespaces=[],
                                 labels=set()),
             priorities=list(DEFAULT_PRIORITIES),
             groupby=GroupBy(label="", order=[]),
@@ -814,7 +814,7 @@ class TestMainOptions:
         # it loads _all_ resources from the local files, even if we want to
         # sync only a subset.
         load_selectors = Selectors(kinds=k8sconfig.kinds,
-                                   labels=None, namespaces=None)
+                                   labels=None, namespaces=[])
 
         # Call test function and verify it passed the correct arguments.
         assert sq.get_resources(config) is False


### PR DESCRIPTION
- Create sensible defaults for `GroupBy` and `Selectors`.
- `Selectors.namespaces` must now always be a list. An empty list implies all namespaces.