### PR TITLE
Switch Selectors, GroupBy and Config to `dataclasses`.

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,9 +1,17 @@
 import pathlib
 from typing import (
-    Any, Collection, Dict, List, NamedTuple, Optional, Set, Tuple, Union,
+    TYPE_CHECKING, Any, Collection, Dict, List, NamedTuple, Optional, Set,
+    Tuple, Union,
 )
 
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    import dataclasses
+    from pydantic.dataclasses import dataclass
+
 
 # Square will first save/deploy the resources in this list in this order.
 # Afterwards it will move on to all those resources not in this list. The order
@@ -149,20 +157,27 @@ class DeploymentPlanMeta(NamedTuple):
 # -----------------------------------------------------------------------------
 #                             Square Configuration
 # -----------------------------------------------------------------------------
-class Selectors(NamedTuple):
+def _factory(ret):
+    return dataclasses.field(default_factory=lambda: ret)
+
+
+@dataclass
+class Selectors:
     """Comprises all the filters to select manifests."""
-    kinds: Set[str] = set(DEFAULT_PRIORITIES)
-    namespaces: List[str] = []
-    labels: Optional[Set[Tuple[str, str]]] = set()
+    kinds: Set[str] = _factory(set(DEFAULT_PRIORITIES))
+    namespaces: List[str] = _factory([])
+    labels: Optional[Set[Tuple[str, str]]] = _factory(set())
 
 
-class GroupBy(NamedTuple):
+@dataclass
+class GroupBy:
     """Define how to organise downloaded manifest on the files system."""
-    label: str = ""             # "app"
-    order: List[str] = []       # ["ns", "label=app", kind"]
+    label: str = ""                  # "app"
+    order: List[str] = _factory([])  # ["ns", "label=app", kind"]
 
 
-class Config(NamedTuple):
+@dataclass
+class Config:
     """Uniform interface into top level Square API."""
     # Path to local manifests eg "./foo"
     folder: Filepath
@@ -177,13 +192,13 @@ class Config(NamedTuple):
     selectors: Selectors = Selectors()
 
     # Sort the manifest in this order, or alphabetically at the end if not in the list.
-    priorities: List[str] = list(DEFAULT_PRIORITIES)
+    priorities: List[str] = _factory(list(DEFAULT_PRIORITIES))
 
     # How to structure the folder directory when syncing manifests.
     groupby: GroupBy = GroupBy()
 
     # Define which fields to skip for which resource.
-    filters: dict = {}
+    filters: dict = _factory({})
 
 
 # -----------------------------------------------------------------------------

--- a/square/main.py
+++ b/square/main.py
@@ -56,7 +56,7 @@ def parse_commandline_args():
     )
     parent.add_argument(
         "-n", "--namespace", type=str, nargs="*",
-        metavar="ns", dest="namespaces",
+        metavar="ns", dest="namespaces", default=[],
         help="List of namespaces (omit to consider all)",
     )
     parent.add_argument(

--- a/square/square.py
+++ b/square/square.py
@@ -56,7 +56,7 @@ def load_config(fname: Filepath) -> Tuple[Config, bool]:
         filters=raw.filters,
         selectors=Selectors(
             kinds=set(raw.selectors.kinds),
-            namespaces=[] or raw.selectors.namespaces,
+            namespaces=raw.selectors.namespaces or [],
             labels={(kv.name, kv.value) for kv in raw.selectors.labels},
         )
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,14 +46,14 @@ class TestResourceCleanup:
         # Use specified a valid set of `selectors.kinds` using various spellings.
         cfg = Config(
             folder=pathlib.Path('/tmp'),
-            kubeconfig=None,
+            kubeconfig="",
             kube_ctx=None,
             selectors=Selectors(
                 kinds={"svc", 'DEPLOYMENT', "Secret"},
                 namespaces=['default'],
                 labels={("app", "morty"), ("foo", "bar")},
             ),
-            groupby=GroupBy("", tuple()),
+            groupby=GroupBy("", []),
             priorities=("Namespace", "Deployment"),
         )
 
@@ -122,7 +122,7 @@ class TestMain:
         assert cfg.folder == Filepath("./")
         assert cfg.priorities == list(DEFAULT_PRIORITIES)
         assert cfg.selectors.kinds == set(DEFAULT_PRIORITIES)
-        assert cfg.selectors.namespaces is None
+        assert cfg.selectors.namespaces == []
         assert cfg.selectors.labels == {("app", "square"), ("foo", "bar")}
         assert set(cfg.filters.keys()) == {
             "_common_", "Service", "ClusterRole", "ClusterRoleBinding",

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -113,7 +113,7 @@ class TestLoadConfig:
         assert cfg.folder == Filepath("./")
         assert cfg.priorities == list(DEFAULT_PRIORITIES)
         assert cfg.selectors.kinds == set(DEFAULT_PRIORITIES)
-        assert cfg.selectors.namespaces is None
+        assert cfg.selectors.namespaces == []
         assert cfg.selectors.labels == {("app", "square"), ("foo", "bar")}
         assert set(cfg.filters.keys()) == {
             "_common_", "Service", "ClusterRole", "ClusterRoleBinding",


### PR DESCRIPTION
Tighten the data types and get a moderate amount of runtime checks.