### PR TITLE
Improve config file structure

### DIFF
--- a/resources/sampleconfig.yaml
+++ b/resources/sampleconfig.yaml
@@ -60,12 +60,10 @@ selectors:
     - StatefulSet
     - Ingress
     - HorizontalPodAutoscaler
-  namespaces: null
+  namespaces: []
   labels:
-    - name: app
-      value: square
-    - name: foo
-      value: bar
+    - [app, square]
+    - [foo, bar]
 
 filters:
   _common_:

--- a/resources/sampleconfig.yaml
+++ b/resources/sampleconfig.yaml
@@ -78,16 +78,10 @@ filters:
         - kubectl.kubernetes.io/last-applied-configuration
         - kubernetes.io/change-cause
     - status
-
-  ClusterRole: []
-  ClusterRoleBinding: []
-  CustomResourceDefinition: []
   ConfigMap:
     - metadata:
       - annotations
       - control-plane.alpha.kubernetes.io/leader
-  CronJob: []
-  DaemonSet: []
   Deployment: []
   HorizontalPodAutoscaler:
     - metadata:
@@ -95,16 +89,7 @@ filters:
         - control-plane.alpha.kubernetes.io/leader
         - autoscaling.alpha.kubernetes.io/conditions
         - autoscaling.alpha.kubernetes.io/current-metrics
-  Ingress: []
-  Namespace: []
-  PersistentVolumeClaim: []
-  PodDisruptionBudget: []
-  Role: []
-  RoleBinding: []
-  Secret: []
   Service:
     - spec:
       - ports:
         - nodePort
-  ServiceAccount: []
-  StatefulSet: []

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -200,6 +200,8 @@ class Config:
     # Define which fields to skip for which resource.
     filters: Dict[str, List[Union[str, dict]]] = _factory({})
 
+    version: str = ""
+
 
 # -----------------------------------------------------------------------------
 #                               Configuration File

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -4,8 +4,6 @@ from typing import (
     Tuple, Union,
 )
 
-from pydantic import BaseModel
-
 if TYPE_CHECKING:
     from dataclasses import dataclass
 else:
@@ -201,33 +199,6 @@ class Config:
     filters: Dict[str, List[Union[str, dict]]] = _factory({})
 
     version: str = ""
-
-
-# -----------------------------------------------------------------------------
-#                               Configuration File
-# -----------------------------------------------------------------------------
-class ConfigFileKeyValue(BaseModel):
-    # To parse the `selectors.labels` section.
-    name: str
-    value: str
-
-
-class ConfigFileSelectors(BaseModel):
-    # Config file equivalent to `Selectors` defined above.
-    kinds: List[str]
-    namespaces: Optional[List[str]]
-    labels: List[ConfigFileKeyValue]
-
-
-class ConfigFile(BaseModel):
-    """Configuration file structure."""
-    version: str
-    kubeconfig: Filepath
-    kubecontext: Optional[str] = None
-    folder: Filepath = Filepath(".")
-    selectors: ConfigFileSelectors
-    priorities: List[str]
-    filters: Dict[str, List[Union[str, dict]]]
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -125,12 +125,7 @@ class TestMain:
         assert cfg.selectors.namespaces == []
         assert cfg.selectors.labels == {("app", "square"), ("foo", "bar")}
         assert set(cfg.filters.keys()) == {
-            "_common_", "Service", "ClusterRole", "ClusterRoleBinding",
-            "CustomResourceDefinition", "ConfigMap",
-            "CronJob", "DaemonSet", "Deployment", "HorizontalPodAutoscaler",
-            "Ingress", "Namespace", "PersistentVolumeClaim",
-            "PodDisruptionBudget", "Role", "RoleBinding", "Secret",
-            "ServiceAccount", "StatefulSet",
+            "_common_", "ConfigMap", "Deployment", "HorizontalPodAutoscaler", "Service"
         }
 
     def test_compile_config_missing_config_file(self, config):

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -117,12 +117,7 @@ class TestLoadConfig:
         assert cfg.selectors.namespaces == []
         assert cfg.selectors.labels == {("app", "square"), ("foo", "bar")}
         assert set(cfg.filters.keys()) == {
-            "_common_", "Service", "ClusterRole", "ClusterRoleBinding",
-            "CustomResourceDefinition", "ConfigMap",
-            "CronJob", "DaemonSet", "Deployment", "HorizontalPodAutoscaler",
-            "Ingress", "Namespace", "PersistentVolumeClaim",
-            "PodDisruptionBudget", "Role", "RoleBinding", "Secret",
-            "ServiceAccount", "StatefulSet"
+            "_common_", "ConfigMap", "Deployment", "HorizontalPodAutoscaler", "Service"
         }
 
     def test_load_config_err(self, tmp_path):


### PR DESCRIPTION
The file now maps exactly to `dtypes.Config`. This will make it easier to deal with external configuration files.