### PR TITLE
Dot square

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -11,6 +11,11 @@ else:
     from pydantic.dataclasses import dataclass
 
 
+Filepath = pathlib.Path
+
+# Square will source all its default values from this configuration file.
+DEFAULT_CONFIG_FILE = Filepath(__file__).parent.parent / "resources/defaultconfig.yaml"
+
 # Square will first save/deploy the resources in this list in this order.
 # Afterwards it will move on to all those resources not in this list. The order
 # in which it does that is undefined.
@@ -39,8 +44,6 @@ DEFAULT_PRIORITIES = (
     # Other.
     "HorizontalPodAutoscaler", "Ingress",
 )
-
-Filepath = pathlib.Path
 
 
 # -----------------------------------------------------------------------------

--- a/square/main.py
+++ b/square/main.py
@@ -10,7 +10,9 @@ import colorama
 import square
 import square.square
 from square import __version__
-from square.dtypes import Config, Filepath, GroupBy, Selectors
+from square.dtypes import (
+    DEFAULT_CONFIG_FILE, Config, Filepath, GroupBy, Selectors,
+)
 
 # Convenience: global logger instance to avoid repetitive code.
 logit = logging.getLogger("square")
@@ -202,7 +204,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
     else:
         # Pick the configuration file, depending on whether the user specified
         # `--no-config`, `--config` and whether a `.square.yaml` file exists.
-        default_cfg = Filepath(__file__).parent.parent / "resources/defaultconfig.yaml"
+        default_cfg = DEFAULT_CONFIG_FILE
         dot_square = Filepath(".square.yaml")
         if p.no_config:
             cfg_file = default_cfg
@@ -394,7 +396,7 @@ def main() -> int:
     if param.parser == "config":
         fname = Filepath(param.folder) / ".square.yaml"
         fname.parent.mkdir(parents=True, exist_ok=True)
-        fname.write_text(open("resources/defaultconfig.yaml").read())
+        fname.write_text(DEFAULT_CONFIG_FILE.read_text())
         print(
             f"Created configuration file <{fname}>.\n"
             "Please open the file in an editor and adjust the values, most notably "

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,8 +11,8 @@ import square.manio as manio
 import square.square as square
 import yaml
 from square.dtypes import (
-    DEFAULT_PRIORITIES, Config, DeltaCreate, DeltaDelete, DeltaPatch,
-    DeploymentPlan, Filepath, GroupBy, JsonPatch, Selectors,
+    DEFAULT_CONFIG_FILE, DEFAULT_PRIORITIES, Config, DeltaCreate, DeltaDelete,
+    DeltaPatch, DeploymentPlan, Filepath, GroupBy, JsonPatch, Selectors,
 )
 
 from .test_helpers import make_manifest
@@ -37,7 +37,7 @@ def fname_param_config(tmp_path) -> Generator[
     fname_kubeconfig = tmp_path / "kubeconfig-dot-square"
 
     # Duplicate the default configuration with the new kubeconfig.
-    ref = yaml.safe_load(Filepath("resources/defaultconfig.yaml").read_text())
+    ref = yaml.safe_load(DEFAULT_CONFIG_FILE.read_text())
     assert "kubeconfig" in ref and "kubecontext" in ref
     ref["kubeconfig"] = str(fname_kubeconfig.absolute())
 
@@ -632,7 +632,7 @@ class TestMain:
             assert main.main() == 0
 
         fname = (folder / ".square.yaml")
-        assert open("resources/defaultconfig.yaml").read() == fname.read_text()
+        assert DEFAULT_CONFIG_FILE.read_text() == fname.read_text()
 
     def test_parse_commandline_args_labels_valid(self):
         """The labels must be returned as (name, value) tuples."""


### PR DESCRIPTION
- Add `--no--config` option to ignore the local `.square.yaml` (if even present).
- Define the default configuration file once in `dtypes`.