### PR TITLE
Dynamic temp folder

### DIFF
--- a/square/k8s.py
+++ b/square/k8s.py
@@ -338,19 +338,19 @@ def load_kind_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig
     if err:
         return (K8sConfig(), True)
 
-    # Kind/Minikube use client certificates to authenticate. We need to pass
-    # those to the HTTP client of our choice when we create the session.
+    # Kind and Minikube use client certificates to authenticate. We need to
+    # pass those to the HTTP client of our choice when we create the session.
     try:
         client_crt = base64.b64decode(user["client-certificate-data"]).decode()
         client_key = base64.b64decode(user["client-key-data"]).decode()
         client_ca = base64.b64decode(cluster["certificate-authority-data"]).decode()
-        path = pathlib.Path("/tmp/")  # nosec
+        path = Filepath(tempfile.mkdtemp())
         p_client_crt = path / "kind-client.crt"
         p_client_key = path / "kind-client.key"
         p_ca = path / "kind.ca"
-        open(p_client_crt, "w").write(client_crt)
-        open(p_client_key, "w").write(client_key)
-        open(p_ca, "w").write(client_ca)
+        p_client_crt.write_text(client_crt)
+        p_client_key.write_text(client_key)
+        p_ca.write_text(client_ca)
         client_cert = K8sClientCert(crt=p_client_crt, key=p_client_key)
 
         # Return the config data.

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -788,32 +788,27 @@ class TestK8sKubeconfig:
 
     def test_load_kind_config_ok(self):
         # Load the K8s configuration for a Kind cluster.
-        fname = "tests/support/kubeconf.yaml"
+        fname = Filepath("tests/support/kubeconf.yaml")
 
-        # Verify the expected output.
-        ref = K8sConfig(
-            url="https://localhost:8443",
-            token="",
-            ca_cert=pathlib.Path("/tmp/kind.ca"),
-            client_cert=k8s.K8sClientCert(
-                crt=pathlib.Path("/tmp/kind-client.crt"),
-                key=pathlib.Path("/tmp/kind-client.key"),
-            ),
-            version="",
-            name="kind",
-        )
-        expected = (ref, False)
-
-        assert k8s.load_kind_config(fname, "kind") == expected
+        ret, err = k8s.load_kind_config(fname, "kind")
+        assert not err
+        assert ret.url == "https://localhost:8443"
+        assert ret.token == ""
+        assert ret.version == ""
+        assert ret.name == "kind"
 
         # Function must also accept pathlib.Path instances.
-        assert expected == k8s.load_kind_config(pathlib.Path(fname), "kind")
+        ret, err = k8s.load_kind_config(pathlib.Path(fname), "kind")
+        assert not err
+        assert ret.url == "https://localhost:8443"
+        assert ret.token == ""
+        assert ret.version == ""
+        assert ret.name == "kind"
 
         # Function must have create the credential files.
-        assert expected == k8s.load_kind_config(fname, "kind")
-        assert pathlib.Path("/tmp/kind.ca").exists()
-        assert pathlib.Path("/tmp/kind-client.crt").exists()
-        assert pathlib.Path("/tmp/kind-client.key").exists()
+        assert ret.ca_cert.exists()
+        assert ret.client_cert.crt.exists()
+        assert ret.client_cert.key.exists()
 
         # Try to load a GKE context - must fail.
         assert k8s.load_kind_config(fname, "gke") == (K8sConfig(), True)

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -1,8 +1,10 @@
 import copy
 import itertools
 import random
+import sys
 import unittest.mock as mock
 
+import pytest
 import square.dotdict as dotdict
 import square.k8s as k8s
 import square.manio as manio
@@ -1159,6 +1161,7 @@ class TestYamlManifestIOIntegration:
         assert (tmp_path / "nonempty.yaml").exists()
         assert not (tmp_path / "empty.yaml").exists()
 
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows")
     def test_save_err_permissions(self, tmp_path):
         """Make temp folder readonly and try to save the manifests."""
         file_data = {"m0.yaml": "Some data"}
@@ -1166,6 +1169,7 @@ class TestYamlManifestIOIntegration:
         assert manio.save_files(tmp_path, file_data) is True
         assert not (tmp_path / "m0.yaml").exists()
 
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows")
     def test_save_remove_stale_err_permissions(self, tmp_path):
         """Place a read-only YAML file into the output folder.
 

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,4 +1,5 @@
 import copy
+import sys
 import unittest.mock as mock
 
 import square.k8s as k8s
@@ -147,11 +148,13 @@ class TestLoadConfig:
         assert not err and cfg.folder == tmp_path / "my-folder"
 
         # An absolute path must ignore the position of ".square.yaml".
-        ref = yaml.safe_load(fname_ref.read_text())
-        ref["folder"] = "/absolute/path"
-        fname.write_text(yaml.dump(ref))
-        cfg, err = sq.load_config(fname)
-        assert not err and cfg.folder == Filepath("/absolute/path")
+        # No idea how to handle this on Windows.
+        if not sys.platform.startswith("win"):
+            ref = yaml.safe_load(fname_ref.read_text())
+            ref["folder"] = "/absolute/path"
+            fname.write_text(yaml.dump(ref))
+            cfg, err = sq.load_config(fname)
+            assert not err and cfg.folder == Filepath("/absolute/path")
 
     def test_common_filters(self, tmp_path):
         """Deal with empty or non-existing `_common_` filter."""


### PR DESCRIPTION
- Replace hard coded `/tmp` folder in `load_kind_config` with a dynamic one.
- Skip certain file related tests on Windows.