### PR TITLE
Bump version: 0.22.0 → 0.22.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.22.0
+current_version = 0.22.1
 commit = True
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![](https://img.shields.io/badge/license-Apache%202-blue.svg)]()
 [![](https://img.shields.io/badge/python-3.7+-blue.svg)]()
-[![](https://img.shields.io/badge/latest-v0.22.0-blue.svg)]()
+[![](https://img.shields.io/badge/latest-v0.22.1-blue.svg)]()
 [![](https://img.shields.io/circleci/project/github/olitheolix/square/master.svg?style=flat)]()
 [![](https://img.shields.io/codecov/c/github/olitheolix/square.svg?style=flat)]()
 [![](https://img.shields.io/badge/status-prod-green.svg)]()
@@ -16,7 +16,7 @@ You can install *Square* in any Python 3.7+ environment with:
 ```console
 foo@bar:~$ pip install kubernetes-square
 foo@bar:~$ square version
-0.22.0
+0.22.1
 ```
 
 Some pre-built binaries are available on the [Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kubernetes-square"
-version = "0.22.0"
+version = "0.22.1"
 description = ""
 authors = ["Oliver Nagy <olitheolix@gmail.com>"]
 packages = [

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -1,6 +1,6 @@
 from . import square
 
-__version__ = '0.22.0'
+__version__ = '0.22.1'
 
 # Expose the main functions of Square directly for convenience.
 get = square.get_resources


### PR DESCRIPTION
Fix dependencies when installing Square via `pip`.