### PR TITLE
Add "translate_resource_kinds" to "square".

### DIFF
--- a/square/main.py
+++ b/square/main.py
@@ -386,12 +386,14 @@ def show_info(cfg: Config) -> bool:
 
 def main() -> int:
     param = parse_commandline_args()
+
+    # Print version information and quit.
     if param.parser == "version":
         print(__version__)
         return 0
 
+    # Create a default ".square.yaml" in the current folder and quit.
     if param.parser == "config":
-        # Create a default ".square.yaml" in the current folder.
         fname = Filepath(param.folder or ".") / ".square.yaml"
         fname.parent.mkdir(parents=True, exist_ok=True)
         fname.write_text(DEFAULT_CONFIG_FILE.read_text())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,8 @@ def k8sconfig() -> Generator[K8sConfig, None, None]:
     cfg.short2kind["service"] = "Service"
     cfg.short2kind["svc"] = "Service"
     cfg.short2kind["secret"] = "Secret"
+    cfg.short2kind["ns"] = "Namespace"
+    cfg.short2kind["namespace"] = "Namespace"
 
     # The set of canonical K8s resources we support.
     cfg.kinds.update({_ for _ in cfg.short2kind.values()})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,7 +95,7 @@ class TestResourceCleanup:
         """Must expand the short names if possible, and leave as is otherwise."""
         m_cluster.side_effect = lambda *args: (k8sconfig, False)
 
-        # Use specified a valid set of `selectors.kinds` using various spellings.
+        # Declare `selectors.kinds` with various resource spellings.
         cfg = Config(
             folder=pathlib.Path('/tmp'),
             kubeconfig="",


### PR DESCRIPTION
The main entry point functions `apply_plan`, `make_plan` and `get_resource` now convert `Config.Selectors.kinds` and `Config.priorities` to the K8s canonical names.

This removes the corresponding burden from the caller.