### PR TITLE
Automatically expand an empty resource list to all resources.

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -109,8 +109,8 @@ class K8sConfig(NamedTuple):
     short2kind: Dict[str, str] = {}
 
     # The set of supported K8s resource kinds, eg {"Deployment", "Service"}.
-    # NOTE: these are the `manifest.kind` spellings. "Deployment" is a kind
-    # whereas "deployment" or "Deployments" are not.
+    # NOTE: these are the `manifest.kind` spellings. "Deployment" is a valid
+    # K8s resource kind, whereas "deployment" or "Deployments" are not.
     kinds: Set[str] = set()
 
 


### PR DESCRIPTION
Square will now replace an empty resource list with all available K8s resources it can manage.

Example:
 - `square get ing` will only retrieve ingresses.
- `square get` will query K8s for all available resource and then get them all.