### PR TITLE
Store label selectors as a list of strings.

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -175,7 +175,7 @@ class Selectors:
     """Comprises all the filters to select manifests."""
     kinds: Set[str] = _factory(set(DEFAULT_PRIORITIES))
     namespaces: List[str] = _factory([])
-    labels: Set[Tuple[str, str]] = _factory(set())
+    labels: List[str] = _factory([])
 
 
 @dataclass

--- a/square/main.py
+++ b/square/main.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import os
-import re
 from typing import Optional, Tuple
 
 import colorama
@@ -18,12 +17,11 @@ logit = logging.getLogger("square")
 
 def parse_commandline_args():
     """Return parsed command line."""
-    def _validate_label(label: str) -> Tuple[str, ...]:
-        """Unpack the labels: "app=square" -> ("app", "square") """
-        pat = re.compile(r"^[a-z0-9][-a-z0-9_.]*=[-A-Za-z0-9_.]*[A-Za-z0-9]$")
-        if pat.match(label) is None:
+    def _validate_label(label: str) -> str:
+        """Sanity check the label"""
+        if not square.square.valid_label(label):
             raise argparse.ArgumentTypeError(label)
-        return tuple(label.split("="))
+        return label
 
     # A dummy top level parser that will become the parent for all sub-parsers
     # to share all its arguments.
@@ -171,13 +169,14 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         folder=Filepath(""),
         kubeconfig=Filepath(""),
         kubecontext=None,
-        selectors=Selectors(set(), namespaces=[], labels=set()),
+        selectors=Selectors(set(), namespaces=[], labels=[]),
         groupby=GroupBy("", []),
         priorities=[],
     ), True
 
     # Convenience.
     p = cmdline_param
+    print(p)
 
     # Load the default configuration unless the user specified an explicit one.
     if p.configfile:
@@ -277,8 +276,9 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
     kubeconfig = Filepath(kubeconfig)
     kubecontext = p.kubecontext or cfg.kubecontext
     namespaces = cfg.selectors.namespaces if p.namespaces is None else p.namespaces
-    sel_labels = cfg.selectors.labels if p.labels is None else set(p.labels)
+    sel_labels = cfg.selectors.labels if p.labels is None else p.labels
     priorities = p.priorities or cfg.priorities
+    print(sel_labels)
     selectors = Selectors(kinds, namespaces, sel_labels)
 
     # Use filters from (default) config file because they cannot be specified

--- a/tests/support/config.yaml
+++ b/tests/support/config.yaml
@@ -73,7 +73,7 @@ selectors:
     - StatefulSet
   namespaces: ["default", "kube-system"]
   labels:
-    - [app, square]
+    - app=square
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -314,7 +314,7 @@ class TestMainPlan:
             selectors=Selectors(
                 kinds=set(priorities),
                 namespaces=[namespace],
-                labels={("app", "test-workflow")}),
+                labels=["app=test-workflow"]),
         )
 
         # ---------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -104,7 +104,7 @@ class TestResourceCleanup:
             selectors=Selectors(
                 kinds=set(),
                 namespaces=['default'],
-                labels={("app", "morty"), ("foo", "bar")},
+                labels=["app=morty", "foo=bar"],
             ),
             groupby=GroupBy("", []),
             priorities=("Namespace", "Deployment"),
@@ -121,7 +121,7 @@ class TestResourceCleanup:
             selectors=Selectors(
                 kinds={"svc", "Deployment"},
                 namespaces=['default'],
-                labels={("app", "morty"), ("foo", "bar")},
+                labels=["app=morty", "foo=bar"],
             ),
             groupby=GroupBy("", []),
             priorities=("Namespace", "Deployment"),
@@ -140,7 +140,7 @@ class TestResourceCleanup:
             selectors=Selectors(
                 kinds=set(),
                 namespaces=['default'],
-                labels={("app", "morty"), ("foo", "bar")},
+                labels=["app=morty", "foo=bar"],
             ),
             groupby=GroupBy("", tuple()),
             priorities=("Namespace", "Deployment"),
@@ -218,7 +218,7 @@ class TestMain:
         assert cfg.selectors == Selectors(
             kinds=set(DEFAULT_PRIORITIES),
             namespaces=["default", "kube-system"],
-            labels={("app", "square")},
+            labels=["app=square"],
         )
         assert cfg.groupby == GroupBy(label="app", order=["ns", "label", "kind"])
         assert set(cfg.filters.keys()) == {
@@ -231,7 +231,7 @@ class TestMain:
         param = types.SimpleNamespace(
             folder="folder-override",
             kinds=["Deployment", "Namespace"],
-            labels=[("app", "square"), ("foo", "bar")],
+            labels=["app=square", "foo=bar"],
             namespaces=["default", "kube-system"],
             kubeconfig=str(kubeconfig_override),
             kubecontext="kubecontext-override",
@@ -251,7 +251,7 @@ class TestMain:
         assert cfg.selectors == Selectors(
             kinds={"Namespace", "Deployment"},
             namespaces=["default", "kube-system"],
-            labels={("app", "square"), ("foo", "bar")},
+            labels=["app=square", "foo=bar"],
         )
         assert cfg.groupby == GroupBy(label="foo", order=["kind", "label", "ns"])
         assert set(cfg.filters.keys()) == {
@@ -453,7 +453,7 @@ class TestMain:
 
         # The defaults must have taken over because the user did not specify
         # new labels etc.
-        assert cfg.selectors.labels == {("app", "square")}
+        assert cfg.selectors.labels == ["app=square"]
         assert cfg.selectors.namespaces == ["default", "kube-system"]
         assert cfg.groupby == GroupBy(label="app", order=["ns", "label", "kind"])
 
@@ -467,7 +467,7 @@ class TestMain:
 
         # This time, the user supplied arguments must have cleared the
         # respective fields.
-        assert cfg.selectors.labels == set()
+        assert cfg.selectors.labels == []
         assert cfg.selectors.namespaces == []
         assert cfg.groupby == GroupBy()
 
@@ -487,7 +487,7 @@ class TestMain:
                 folder=Filepath(""),
                 kubeconfig=Filepath(""),
                 kubecontext=None,
-                selectors=Selectors(set(), [], set()),
+                selectors=Selectors(set(), [], []),
                 groupby=GroupBy("", []),
                 priorities=[],
             ), True)
@@ -500,7 +500,7 @@ class TestMain:
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kubecontext=None,
-            selectors=Selectors(set(), [], set()),
+            selectors=Selectors(set(), [], []),
             groupby=GroupBy("", []),
             priorities=[],
         ), True
@@ -576,7 +576,7 @@ class TestMain:
             del args
 
         # These two deviate from the values in `tests/support/config.yaml`.
-        config.selectors.labels = {("app", "demo")}
+        config.selectors.labels = ["app=demo"]
         config.selectors.namespaces = ["default"]
 
         # Every main function must have been called exactly once.
@@ -604,7 +604,7 @@ class TestMain:
             del args
 
         # These two deviate from the values in `tests/support/config.yaml`.
-        config.selectors.labels = {("app", "demo")}
+        config.selectors.labels = ["app=demo"]
         config.selectors.namespaces = ["default"]
 
         # Every main function must have been called exactly once.
@@ -718,13 +718,13 @@ class TestMain:
         # One label.
         with mock.patch("sys.argv", ["square.py", "get", "all", "-l", "foo=bar"]):
             ret = main.parse_commandline_args()
-            assert ret.labels == [("foo", "bar")]
+            assert ret.labels == ["foo=bar"]
 
         # Two labels.
         with mock.patch("sys.argv",
                         ["square.py", "get", "all", "-l", "foo=bar", "x=y"]):
             ret = main.parse_commandline_args()
-            assert ret.labels == [("foo", "bar"), ("x", "y")]
+            assert ret.labels == ["foo=bar", "x=y"]
 
     def test_parse_commandline_args_priority(self):
         """Custom priorities must override the default."""
@@ -791,7 +791,7 @@ class TestMain:
             folder=Filepath(""),
             kubeconfig=Filepath(""),
             kubecontext=None,
-            selectors=Selectors(set(), [], set()),
+            selectors=Selectors(set(), [], []),
             groupby=GroupBy("", []),
             priorities=[],
         )


### PR DESCRIPTION
Change the internal representation of label selectors to strings like `key=value`.

This makes the entries in `.square.yaml` more readable and intuitive, and will also allow future extension to the label syntax, eg regex matching.