### PR TITLE
Strip all manifests before creating the plan.

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -442,16 +442,16 @@ def make_manifest(kind: str, namespace: str, name: str,
         'metadata': {
             'name': name,
             'labels': labels,
-            'foo': 'bar',
         },
         'spec': {
             'finalizers': ['kubernetes']
         },
-        'status': {
-            'some': 'status',
-        },
         'garbage': 'more garbage',
     }
+
+    # Do not include an empty label dict.
+    if not labels:
+        del manifest["metadata"]["labels"]
 
     # Only create namespace entry if one was specified.
     if namespace is not None:

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -1113,20 +1113,6 @@ class TestDiff:
         assert "-  name: name1" in diff_str
         assert "+  name: name2" in diff_str
 
-    def test_diff_err(self, config, k8sconfig):
-        """Diff two valid manifests and verify the output."""
-        # Create two valid manifests, then stunt one in such a way that
-        # `essential` will reject it.
-        valid = make_manifest("Deployment", "namespace", "name1")
-        invalid = make_manifest("Deployment", "namespace", "name2")
-        del invalid["kind"]
-
-        # Test function must return with an error, irrespective of which
-        # manifest was invalid.
-        assert manio.diff(config, k8sconfig, valid, invalid) == ("", True)
-        assert manio.diff(config, k8sconfig, invalid, valid) == ("", True)
-        assert manio.diff(config, k8sconfig, invalid, invalid) == ("", True)
-
 
 class TestYamlManifestIOIntegration:
     """These integration tests all write files to temporary folders."""


### PR DESCRIPTION
Strip all manifests once in `compile_plan`, instead of in two different places.

Aside from consistency, the filters now apply to newly created resources as well, instead of just to the patches for existing resources.