### PR TITLE
Close coverage gaps

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,9 @@ exclude_lines =
 omit =
     # Exclude test files from coverage report.
     tests/*
+    delme*
+    square/__main__.py
+    runme.py
 
 [html]
 directory = htmlcov

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -715,6 +715,19 @@ class TestK8sKubeconfig:
             name="",
         )
 
+    @mock.patch.object(k8s, "load_auto_config")
+    @mock.patch.object(k8s, "version")
+    @mock.patch.object(k8s, "compile_api_endpoints")
+    def test_cluster_config(self, m_compile_endpoints, m_version, m_load_auto, k8sconfig):
+        kubeconfig = Filepath("kubeconfig")
+        kubecontext = False
+
+        m_load_auto.return_value = (k8sconfig, False)
+        m_version.return_value = (k8sconfig, False)
+        m_compile_endpoints.return_value = False
+
+        assert k8s.cluster_config(kubeconfig, kubecontext) == (k8sconfig, False)
+
     @mock.patch.object(k8s, "load_incluster_config")
     @mock.patch.object(k8s, "load_minikube_config")
     @mock.patch.object(k8s, "load_kind_config")

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -866,7 +866,7 @@ class TestPlan:
         # definition differs. This will ensure a non-empty patch in the plan.
         loc_man = srv_man = {meta: make_manifest("Namespace", None, "ns1")}
 
-        # Simulate an error in `compile_plan`.
+        # Simulate an error in `partition_manifests`.
         m_part.return_value = (None, True)
         assert sq.compile_plan(config, k8sconfig, loc_man, srv_man) == err_resp
 


### PR DESCRIPTION
- Exclude `runme.sh` and `square.__main__.py` from the coverage report.
- Add missing test for `k8s.cluster_config`.
- Some TLC