### PR TITLE
Improve default filter for Services.

### DIFF
--- a/resources/defaultconfig.yaml
+++ b/resources/defaultconfig.yaml
@@ -126,5 +126,7 @@ filters:
 
   Service:
     - spec:
+      - clusterIP
       - ports:
         - nodePort
+      - sessionAffinity


### PR DESCRIPTION
Add `Service.spec.sessionAffinity` and `Service.spec.clusterIP` to the default exclusion filters.