### PR TITLE
Include missing resource folder in Python wheel.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ authors = ["Oliver Nagy <olitheolix@gmail.com>"]
 packages = [
     { include = "square" },
 ]
+include = ["resources/defaultconfig.yaml"]
+
 
 [tool.poetry.dependencies]
 colorama = "^0.4.1"


### PR DESCRIPTION
The Python wheels were missing the `defaultconfig`. Now they are included.

The source distribution still does not contain the file due to a bug in Poetry.