### PR TITLE
Implement "match_api_version".

### DIFF
--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -2060,3 +2060,29 @@ class TestDownloadManifests:
             mock.call(k8sconfig.client, res_deploy.url),
             mock.call(k8sconfig.client, res_ns.url),
         ]
+
+    @mock.patch.object(k8s, 'get')
+    def test_download_single(self, m_get, k8sconfig):
+        """Download a single manifest.
+
+        The test only mocks the K8s API call.
+
+        """
+        manifest = make_manifest("Deployment", "ns", "name")
+        meta = manio.make_meta(manifest)
+        assert meta == MetaManifest("apps/v1", "Deployment", "ns", "name")
+
+        # Mock the K8s response to return a valid manifest.
+        m_get.return_value = (manifest, False)
+
+        # Resource URLs.
+        res, err = resource(k8sconfig, meta)
+        assert not err
+
+        # Test function must successfully download the resource.
+        assert manio.download_single(k8sconfig, res) == (meta, manifest, False)
+
+        # Simulate a download error.
+        m_get.return_value = (manifest, True)
+        ret = manio.download_single(k8sconfig, res)
+        assert ret == (MetaManifest("", "", "", ""), {}, True)


### PR DESCRIPTION
Square will now heed the `apiVersion` defined in the local manifests instead of overriding it to the preferred version.