### PR TITLE
Add HPA annotation to default filter.

### DIFF
--- a/square/schemas.py
+++ b/square/schemas.py
@@ -52,6 +52,7 @@ def default():
                 "deployment.kubernetes.io/revision",
                 "kubectl.kubernetes.io/last-applied-configuration",
                 "kubernetes.io/change-cause",
+                "autoscaling.alpha.kubernetes.io/conditions",
             ]},
             "creationTimestamp",
             "generation",

--- a/tests/support/config.yaml
+++ b/tests/support/config.yaml
@@ -97,6 +97,7 @@ filters:
         - deployment.kubernetes.io/revision
         - kubectl.kubernetes.io/last-applied-configuration
         - kubernetes.io/change-cause
+        - autoscaling.alpha.kubernetes.io/conditions
       - creationTimestamp
       - generation
       - resourceVersion

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -34,6 +34,7 @@ class TestMainGet:
                     "deployment.kubernetes.io/revision",
                     "kubectl.kubernetes.io/last-applied-configuration",
                     "kubernetes.io/change-cause",
+                    "autoscaling.alpha.kubernetes.io/conditions",
                 ]},
                 "creationTimestamp",
                 "generation",
@@ -56,6 +57,7 @@ class TestMainGet:
                     "deployment.kubernetes.io/revision",
                     "kubectl.kubernetes.io/last-applied-configuration",
                     "kubernetes.io/change-cause",
+                    "autoscaling.alpha.kubernetes.io/conditions",
                 ]},
                 "creationTimestamp",
                 "generation",
@@ -71,6 +73,7 @@ class TestMainGet:
         expected = [
             {"metadata": [
                 {"annotations": [
+                    "autoscaling.alpha.kubernetes.io/conditions",
                     "deployment.kubernetes.io/revision",
                     "kubectl.kubernetes.io/last-applied-configuration",
                     "kubernetes.io/change-cause",
@@ -99,6 +102,7 @@ class TestMainGet:
                     "deployment.kubernetes.io/revision",
                     "kubectl.kubernetes.io/last-applied-configuration",
                     "kubernetes.io/change-cause",
+                    "autoscaling.alpha.kubernetes.io/conditions",
                 ]},
                 "creationTimestamp",
                 "generation",


### PR DESCRIPTION
Ignore `autoscaling.alpha.kubernetes.io/conditions` in all manifests.