### PR TITLE
Use the defaults from the default config file.

### DIFF
--- a/resources/defaultconfig.yaml
+++ b/resources/defaultconfig.yaml
@@ -102,6 +102,7 @@ filters:
         - deployment.kubernetes.io/revision
         - kubectl.kubernetes.io/last-applied-configuration
         - kubernetes.io/change-cause
+        - autoscaling.alpha.kubernetes.io/conditions
       - creationTimestamp
       - generation
       - resourceVersion

--- a/square/manio.py
+++ b/square/manio.py
@@ -528,8 +528,19 @@ def strip(
         # Remove all empty sub-dictionaries from `removed`.
         return {k: v for k, v in removed.items() if v != {}}
 
-    # Get the filters for the current resource. Use the default one if none exists.
-    filters = manifest_filters.get(manifest["kind"], square.cfgfile.default())
+    # Look up the filters for the current resource in the following order:
+    # 1) Supplied `filters`
+    # 2) Square default filters for this resource `kind`.
+    # 3) Square default filters that apply to all resource kinds.
+    # Pick the first one that matches.
+    kind = manifest["kind"]
+    filters = manifest_filters.get(
+        kind,
+        square.DEFAULT_CONFIG.filters.get(
+            kind,
+            square.DEFAULT_CONFIG.filters["_common_"]
+        )
+    )
     if not square.cfgfile.valid(filters):
         return ret_err
 

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -953,8 +953,13 @@ class TestManifestValidation:
         assert out == expected
         assert removed == {"spec": {"ports": [{"nodePort": 1}, {"nodePort": 3}]}}
 
-    def test_strip_missing_schema(self, k8sconfig):
-        """Remove default fields like `metadata.uid` in the absence of a filter."""
+    def test_strip_default_filters(self, k8sconfig):
+        """Must fall back to default filters unless otherwise specified.
+
+        Here we expect the function to strip out the `metadata.uid` because it
+        is part of the default filters (see `square/resources/defaultconfig.yaml`).
+
+        """
         manifest = {
             "apiVersion": "v1",
             "kind": "Service",


### PR DESCRIPTION
Fall back to the exact same resource filters that a vanilla `.square` file would declare as well.

This is purely for consistency.