### PR TITLE
Use all namespaces unless the user declares otherwise

### DIFF
--- a/resources/defaultconfig.yaml
+++ b/resources/defaultconfig.yaml
@@ -1,4 +1,4 @@
-# Square configuration Syntax.
+# Square configuration syntax.
 version: v1.0
 
 # Kubernetes credentials.
@@ -51,21 +51,21 @@ groupby:
 
 # -----------------------------------------------------------------------------
 # Square will create resources in this order, and delete them in reverse order.
-# This list need not be comprehensive. If Square encounters a resource not
-# listed here, then it will create them last and delete them first.
+# This list need not be complete. If Square encounters an unlisted resource it
+# is tantamount to adding that resource to the end of that list.
 # -----------------------------------------------------------------------------
 priorities:
-  # Custom Resources should come first.
+  # Custom Resources come first.
   - CustomResourceDefinition
 
   # Common non-namespaced resources.
   - ClusterRole
   - ClusterRoleBinding
 
-  # Namespaces must come before any namespaced resources,
+  # Namespaces must come before any namespaced resources.
   - Namespace
 
-  # Configuration and PVC before Deployments & friends use them.
+  # Configuration and PVC before Deployments & friends that may use them.
   - ConfigMap
   - PersistentVolumeClaim
   - Secret
@@ -75,17 +75,17 @@ priorities:
   - RoleBinding
   - ServiceAccount
 
-  # Define Services before creating Deployments & friends.
+  # Define Services before Deployments & friends.
   - PodDisruptionBudget
   - Service
 
-  # Everything that will spawn pods.
+  # Resources that will spawn pods.
   - CronJob
   - DaemonSet
   - Deployment
   - StatefulSet
 
-  # Other.
+  # Everything else.
   - HorizontalPodAutoscaler
   - Ingress
 

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -17,9 +17,13 @@ if getattr(sys, '_MEIPASS', None):
 else:
     BASE_DIR = pathlib.Path(__file__).parent.parent
 
-# Square will source all its default values from this configuration file.
+# Square will source all its default values from this configuration file. The
+# only exceptions are the namespaces. By default, Square will target all the
+# namespaces whereas the specimen only declares "default" unless the user
+# explicitly says otherwise via the command line arguments or ".square.yaml".
 DEFAULT_CONFIG_FILE = BASE_DIR / "resources" / "defaultconfig.yaml"
 DEFAULT_CONFIG, err = load(DEFAULT_CONFIG_FILE)
+DEFAULT_CONFIG.selectors.namespaces.clear()
 assert not err
 
 # ---------------------------------------------------------------------------

--- a/square/main.py
+++ b/square/main.py
@@ -180,11 +180,11 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         logit.info(f"Loading configuration file <{p.configfile}>")
         cfg, err = square.cfgfile.load(p.configfile)
 
-        # Look for `--kubeconfig`. Default to the value in config file.
+        # Look for `--kubeconfig`. Defaults to the value in config file.
         kubeconfig = p.kubeconfig or cfg.kubeconfig
     else:
-        # Pick the configuration file, depending on whether the user specified
-        # `--no-config`, or `--config` and whether or not `.square.yaml` exists.
+        # Pick the configuration file. Depends on whether the user specified
+        # `--no-config`, `--config` and if `.square.yaml` exists.
         default_cfg = DEFAULT_CONFIG_FILE
         dot_square = Filepath(".square.yaml")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -164,9 +164,11 @@ class TestMain:
         assert hasattr(square, "apply_plan")
         assert hasattr(square, "show_plan")
 
-        # Must have loaded the configuration file.
+        # Must have loaded the default configuration file but wiped the
+        # namespace selector.
         cfg, err = cfgfile.load(DEFAULT_CONFIG_FILE)
         assert not err
+        cfg.selectors.namespaces.clear()
         assert square.DEFAULT_CONFIG == cfg
 
     def test_compile_config_basic(self, fname_param_config):


### PR DESCRIPTION
This fixes a regression. Now that Square reads the `.square.yaml` specimen for all its defaults it also meant that, by default, it would only target the `default` namespace. This PR fixes this.