### PR TITLE
Tighten CI pipeline

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,8 +3,8 @@ branch = True
 
 [report]
 exclude_lines =
-    # Ignore the main entry point.
-    if __name__ == .__main__.:
+    # Ignore all lines with this comment string.
+    codecov-skip
 
     # Only runs inside a PyInstaller bundle.
     _MEIPASS

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,10 +33,17 @@ jobs:
           cd ./integration-test-cluster
           ./start_cluster.sh
           cd ..
-      - name: Run Unit Tests
-        run: |
-          pytest --cov=square --cov-report=xml
-          pipenv run mypy --ignore-missing-imports --allow-redefinition square/*.py
+
+      - name: Tests - Linting
+        run: isort --check-only ./
+
+      # Break if coverage drops below 100%.
+      - name: Tests - Unit and Integration
+        run: pytest --cov=square --cov-report=term-missing --cov-report=xml --cov-fail-under=100
+
+      - name: Tests - Static analysis
+        run: pipenv run mypy --ignore-missing-imports --allow-redefinition square/*.py
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,4 @@ multi_line_output = 5
 
 [tool:pytest]
 addopts = -p no:warnings
+norecursedirs = .git

--- a/square/__main__.py
+++ b/square/__main__.py
@@ -2,7 +2,7 @@ import sys
 
 import square.main
 
-if __name__ == '__main__':
+if __name__ == '__main__':      # codecov-skip
     try:
         sys.exit(square.main.main())
     except KeyboardInterrupt:


### PR DESCRIPTION
No functional changes to the code but the CI pipeline is now more strict.

- Enforce 100% coverage.
- Lint the import statements via `isort`.
- Introduce an explicit `codecov-skip` tag to mark the code segements that cannot be tested.