### PR TITLE
Bugfix: allow `part/name=value` labels.

### DIFF
--- a/square/square.py
+++ b/square/square.py
@@ -584,18 +584,18 @@ def valid_label(label: str) -> bool:
     try:
         # Split `app=part/file` into (`app`, `part/value`).
         assert label.count("=") == 1
-        name, tmp = label.split("=")
+        tmp, value = label.split("=")
 
         # Split on the "/"
         # "part/value" -> ("part", "value")
         # "value" -> ("", "value")
-        part, _, value = tmp.rpartition("/")
+        part, _, name = tmp.rpartition("/")
         del label, _
 
         # If the label contains a "/" then validate its "part" component.
         assert len(name) > 0
         if "/" in tmp:
-            assert len(part) > 0 and pat.match(part)
+            assert pat.match(part)
 
         # All components must be at most 64 characters long.
         assert max(len(name), len(part), len(value)) < 64

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -822,7 +822,7 @@ class TestMain:
         """Must abort on invalid labels."""
         invalid_labels = (
             "foo", "foo=", "=foo", "foo=bar=foobar", "foo==bar",
-            "fo/o=bar",
+            "foo=ba/r",
         )
         for label in invalid_labels:
             with mock.patch("sys.argv", ["square.py", "get", "all", "-l", label]):

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -132,6 +132,9 @@ class TestBasic:
 
     def test_valid_label(self):
         """Test label values (not their key names)."""
+        # A specific example of a valid label that trigger a bug once.
+        assert sq.valid_label("dh/repo=pd-devops-charts")
+
         # Valid specimen.
         valid = ["foo", "foo/bar", "f/oo", "tags.datadoghq.com/service"]
 
@@ -144,8 +147,8 @@ class TestBasic:
             "foo//bar", "/bar", "foo/", "tags.datadoghq.com/",
         ]
 
-        valid = [f"name={_}" for _ in valid]
-        invalid = [f"name={_}" for _ in invalid]
+        valid = [f"{_}=value" for _ in valid]
+        invalid = [f"{_}=value" for _ in invalid]
 
         for name in valid:
             assert sq.valid_label(name)


### PR DESCRIPTION
In #299 I added support for K8s labels with a `/` as defined by K8s. However, I did it wrong.

I added support for eg `foo=bar/blah` whereas I should have added support for eg `foo/bar=blah`. The first example is actually invalid and K8s will reject it.