### PR TITLE
TLC PyInstaller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build Linux Binary
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv pyinstaller==4.2
+          pip install pipenv pyinstaller==4.9
           pipenv install --system
 
           pyinstaller square.spec --clean
@@ -40,7 +40,7 @@ jobs:
       - name: Build Windows Binary
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv pyinstaller==4.2 macholib pypiwin32 atomicwrites
+          pip install pipenv pyinstaller==4.9 macholib pypiwin32 atomicwrites
           pipenv install --system
 
           pyinstaller square.spec --clean
@@ -61,7 +61,7 @@ jobs:
       - name: Build MacOS Binary
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv pyinstaller==4.2
+          pip install pipenv pyinstaller==4.9
           pipenv install --system
 
           pyinstaller square.spec --clean

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Unit tests.
 htmlcov/
 .coverage*
+.ropeproject/
 
 # Binaries.
 build/

--- a/Pipfile
+++ b/Pipfile
@@ -24,7 +24,6 @@ bumpversion = "*"
 sh = "*"
 pytest-pycodestyle = "*"
 pytest-cov = "*"
-pyinstaller = "==3.6"
 types-pyyaml = "*"
 types-requests = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bcb2e30f2510dd5945f161ff2c216c3ce52e6454a9f6b666bada9c8adb3b4f85"
+            "sha256": "a38477d12eac0cbf28ad774d54605c09d33908f638b3d031a3e5a7179420e0e5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -264,7 +264,7 @@
                 "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
                 "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
             ],
-            "markers": "python_version > '3.0'",
+            "markers": "python_version >= '3.1'",
             "version": "==3.0.7"
         },
         "pyyaml": {
@@ -327,7 +327,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "soupsieve": {
@@ -364,13 +364,6 @@
         }
     },
     "develop": {
-        "altgraph": {
-            "hashes": [
-                "sha256:743628f2ac6a7c26f5d9223c91ed8ecbba535f506f4b6f558885a8a56a105857",
-                "sha256:ebf2269361b47d97b3b88e696439f6e4cbc607c17c51feb1754f90fb79839158"
-            ],
-            "version": "==0.17.2"
-        },
         "attrs": {
             "hashes": [
                 "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
@@ -641,19 +634,12 @@
             "markers": "python_version >= '3.5'",
             "version": "==2.11.2"
         },
-        "pyinstaller": {
-            "hashes": [
-                "sha256:3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7"
-            ],
-            "index": "pypi",
-            "version": "==3.6"
-        },
         "pyparsing": {
             "hashes": [
                 "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
                 "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
             ],
-            "markers": "python_version > '3.0'",
+            "markers": "python_version >= '3.1'",
             "version": "==3.0.7"
         },
         "pytest": {
@@ -716,7 +702,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tomli": {


### PR DESCRIPTION
- Update PyInstaller from v4.2 to v4.9 in the GitHub action to create a release build.
- Remove PyInstaller as a Square dependency because it is superfluous.