### PR TITLE
Support filter callback.

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,7 +1,7 @@
 import pathlib
 from typing import (
-    TYPE_CHECKING, Any, Collection, Dict, List, NamedTuple, Optional, Set,
-    Tuple, Union,
+    TYPE_CHECKING, Any, Callable, Collection, Dict, List, NamedTuple, Optional,
+    Set, Tuple, Union,
 )
 
 if TYPE_CHECKING:
@@ -198,6 +198,10 @@ class Config:
 
     # Define which fields to skip for which resource.
     filters: Dict[str, List[Union[str, dict]]] = _factory({})
+
+    # Callable: will be invoked for every local/server manifest that requires
+    # patching before the actual patch will be computed.
+    patch_callback: Optional[Callable] = None
 
     version: str = ""
 

--- a/square/main.py
+++ b/square/main.py
@@ -296,6 +296,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         groupby=groupby,
         priorities=priorities,
         filters=filters,
+        patch_callback=None,
     )
     return cfg, False
 

--- a/square/manio.py
+++ b/square/manio.py
@@ -466,14 +466,14 @@ def diff(config: Config,
         local: dict
             Local manifest.
         server: dict
-            Local manifest.
+            Server manifest.
 
     Returns:
         str: human readable diff string as the Unix `diff` utility would
         produce it.
 
     """
-    # Precaution: undo the DotDicts to ensure the YAML parse will accept them.
+    # Precaution: undo the DotDicts to ensure the YAML parser will accept them.
     srv = square.dotdict.undo(server)
     loc = square.dotdict.undo(local)
     srv_lines = yaml.dump(srv, default_flow_style=False, Dumper=Dumper).splitlines()


### PR DESCRIPTION
Allow users to specify a callback function for each patch. This function can modify the client/server side manifests before Square will compute the patch.

The intended use case is to ignore fields that cannot be reached with the existing `Config.filters`, for instance elements inside a list like `.spec.containers[1].image`.

This mechanism will also pave the way for better filter semantics outside Square. For instance, one could now write a filter that will automatically ignore all managed fields.

Note that the callback will only be called for resources that need patching since I do not see a use case for filtering resources that should be created or deleted.