### PR TITLE
Upgrade integration test cluster to v1.24

### DIFF
--- a/integration-test-cluster/square-tests-1.yaml
+++ b/integration-test-cluster/square-tests-1.yaml
@@ -77,7 +77,7 @@ spec:
 
 ---
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello-1
@@ -221,7 +221,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demoapp-1
@@ -234,9 +234,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: demoapp
-          servicePort: 80
+          service:
+            name: demoapp
+            port:
+              name: http
         path: /
+        pathType: Prefix
 
 ---
 
@@ -345,7 +348,7 @@ spec:
 
 ---
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: demoapp-1
@@ -358,7 +361,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: democrds.mycrd.com
@@ -368,12 +371,23 @@ spec:
   conversion:
     strategy: None
   group: mycrd.com
-  version: v1
   versions:
     - name: v1
       served: true
       storage: true
-  preserveUnknownFields: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                fooStr:
+                  type: string
+                fooInt:
+                  type: integer
+
+  preserveUnknownFields: false
   scope: Namespaced
   names:
     plural: democrds
@@ -382,17 +396,6 @@ spec:
     listKind: DemoCRDList
     shortNames:
     - democrd
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          properties:
-            fooStr:
-              type: string
-            fooInt:
-              type: integer
 
 ---
 

--- a/integration-test-cluster/square-tests-2.yaml
+++ b/integration-test-cluster/square-tests-2.yaml
@@ -56,7 +56,7 @@ spec:
 
 ---
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello-1
@@ -166,7 +166,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demoapp-1
@@ -179,9 +179,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: demoapp
-          servicePort: 80
+          service:
+            name: demoapp
+            port:
+              name: http
         path: /
+        pathType: Prefix
 
 ---
 

--- a/integration-test-cluster/start_cluster.sh
+++ b/integration-test-cluster/start_cluster.sh
@@ -15,7 +15,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7
+  image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
 EOF
 
 # Create cluster, then delete its config file.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -40,13 +40,6 @@ def k8s_apis(config: K8sConfig):
             namespaced=False,
             url=f"{config.url}/apis/rbac.authorization.k8s.io/v1",
         ),
-        ("ClusterRole", "rbac.authorization.k8s.io/v1beta1"): K8sResource(
-            apiVersion="rbac.authorization.k8s.io/v1beta1",
-            kind="ClusterRole",
-            name="clusterroles",
-            namespaced=False,
-            url=f"{config.url}/apis/rbac.authorization.k8s.io/v1beta1",
-        ),
         ("ClusterRoleBinding", ""): K8sResource(
             apiVersion="rbac.authorization.k8s.io/v1",
             kind="ClusterRoleBinding",
@@ -60,13 +53,6 @@ def k8s_apis(config: K8sConfig):
             name="clusterrolebindings",
             namespaced=False,
             url=f"{config.url}/apis/rbac.authorization.k8s.io/v1",
-        ),
-        ("ClusterRoleBinding", "rbac.authorization.k8s.io/v1beta1"): K8sResource(
-            apiVersion="rbac.authorization.k8s.io/v1beta1",
-            kind="ClusterRoleBinding",
-            name="clusterrolebindings",
-            namespaced=False,
-            url=f"{config.url}/apis/rbac.authorization.k8s.io/v1beta1",
         ),
         ("ConfigMap", ""): K8sResource(
             apiVersion="v1",
@@ -83,32 +69,32 @@ def k8s_apis(config: K8sConfig):
             url=f"{config.url}/api/v1",
         ),
         ("CronJob", ""): K8sResource(
-            apiVersion="batch/v1beta1",
+            apiVersion="batch/v1",
             kind="CronJob",
             name="cronjobs",
             namespaced=True,
-            url=f"{config.url}/apis/batch/v1beta1",
+            url=f"{config.url}/apis/batch/v1",
         ),
-        ("CronJob", "batch/v1beta1"): K8sResource(
-            apiVersion="batch/v1beta1",
+        ("CronJob", "batch/v1"): K8sResource(
+            apiVersion="batch/v1",
             kind="CronJob",
             name="cronjobs",
             namespaced=True,
-            url=f"{config.url}/apis/batch/v1beta1",
+            url=f"{config.url}/apis/batch/v1",
         ),
         ("CustomResourceDefinition", ""): K8sResource(
-            apiVersion="apiextensions.k8s.io/v1beta1",
+            apiVersion="apiextensions.k8s.io/v1",
             kind="CustomResourceDefinition",
             name="customresourcedefinitions",
             namespaced=False,
-            url=f"{config.url}/apis/apiextensions.k8s.io/v1beta1",
+            url=f"{config.url}/apis/apiextensions.k8s.io/v1",
         ),
-        ("CustomResourceDefinition", "apiextensions.k8s.io/v1beta1"): K8sResource(
-            apiVersion="apiextensions.k8s.io/v1beta1",
+        ("CustomResourceDefinition", "apiextensions.k8s.io/v1"): K8sResource(
+            apiVersion="apiextensions.k8s.io/v1",
             kind="CustomResourceDefinition",
             name="customresourcedefinitions",
             namespaced=False,
-            url=f"{config.url}/apis/apiextensions.k8s.io/v1beta1",
+            url=f"{config.url}/apis/apiextensions.k8s.io/v1",
         ),
         ("DaemonSet", ""): K8sResource(
             apiVersion="apps/v1",
@@ -123,20 +109,6 @@ def k8s_apis(config: K8sConfig):
             name="daemonsets",
             namespaced=True,
             url=f"{config.url}/apis/apps/v1",
-        ),
-        ("DaemonSet", "apps/v1beta2"): K8sResource(
-            apiVersion="apps/v1beta2",
-            kind="DaemonSet",
-            name="daemonsets",
-            namespaced=True,
-            url=f"{config.url}/apis/apps/v1beta2",
-        ),
-        ("DaemonSet", "extensions/v1beta1"): K8sResource(
-            apiVersion="extensions/v1beta1",
-            kind="DaemonSet",
-            name="daemonsets",
-            namespaced=True,
-            url=f"{config.url}/apis/extensions/v1beta1",
         ),
         ("DemoCRD", ""): K8sResource(
             apiVersion="mycrd.com/v1",
@@ -166,33 +138,12 @@ def k8s_apis(config: K8sConfig):
             namespaced=True,
             url=f"{config.url}/apis/apps/v1",
         ),
-        ("Deployment", "apps/v1beta1"): K8sResource(
-            apiVersion="apps/v1beta1",
-            kind="Deployment",
-            name="deployments",
-            namespaced=True,
-            url=f"{config.url}/apis/apps/v1beta1",
-        ),
-        ("Deployment", "apps/v1beta2"): K8sResource(
-            apiVersion="apps/v1beta2",
-            kind="Deployment",
-            name="deployments",
-            namespaced=True,
-            url=f"{config.url}/apis/apps/v1beta2",
-        ),
-        ("Deployment", "extensions/v1beta1"): K8sResource(
-            apiVersion="extensions/v1beta1",
-            kind="Deployment",
-            name="deployments",
-            namespaced=True,
-            url=f"{config.url}/apis/extensions/v1beta1",
-        ),
         ("HorizontalPodAutoscaler", ""): K8sResource(
-            apiVersion="autoscaling/v1",
+            apiVersion="autoscaling/v2",
             kind="HorizontalPodAutoscaler",
             name="horizontalpodautoscalers",
             namespaced=True,
-            url=f"{config.url}/apis/autoscaling/v1",
+            url=f"{config.url}/apis/autoscaling/v2",
         ),
         ("HorizontalPodAutoscaler", "autoscaling/v1"): K8sResource(
             apiVersion="autoscaling/v1",
@@ -200,6 +151,13 @@ def k8s_apis(config: K8sConfig):
             name="horizontalpodautoscalers",
             namespaced=True,
             url=f"{config.url}/apis/autoscaling/v1",
+        ),
+        ("HorizontalPodAutoscaler", "autoscaling/v2"): K8sResource(
+            apiVersion="autoscaling/v2",
+            kind="HorizontalPodAutoscaler",
+            name="horizontalpodautoscalers",
+            namespaced=True,
+            url=f"{config.url}/apis/autoscaling/v2",
         ),
         ("HorizontalPodAutoscaler", "autoscaling/v2beta1"): K8sResource(
             apiVersion="autoscaling/v2beta1",
@@ -216,25 +174,18 @@ def k8s_apis(config: K8sConfig):
             url=f"{config.url}/apis/autoscaling/v2beta2",
         ),
         ("Ingress", ""): K8sResource(
-            apiVersion="extensions/v1beta1",
+            apiVersion="networking.k8s.io/v1",
             kind="Ingress",
             name="ingresses",
             namespaced=True,
-            url=f"{config.url}/apis/extensions/v1beta1",
+            url=f"{config.url}/apis/networking.k8s.io/v1",
         ),
-        ("Ingress", "extensions/v1beta1"): K8sResource(
-            apiVersion="extensions/v1beta1",
+        ("Ingress", "networking.k8s.io/v1"): K8sResource(
+            apiVersion="networking.k8s.io/v1",
             kind="Ingress",
             name="ingresses",
             namespaced=True,
-            url=f"{config.url}/apis/extensions/v1beta1",
-        ),
-        ("Ingress", "networking.k8s.io/v1beta1"): K8sResource(
-            apiVersion="networking.k8s.io/v1beta1",
-            kind="Ingress",
-            name="ingresses",
-            namespaced=True,
-            url=f"{config.url}/apis/networking.k8s.io/v1beta1",
+            url=f"{config.url}/apis/networking.k8s.io/v1",
         ),
         ("Job", ""): K8sResource(
             apiVersion="batch/v1",
@@ -307,18 +258,18 @@ def k8s_apis(config: K8sConfig):
             url=f"{config.url}/api/v1",
         ),
         ("PodDisruptionBudget", ""): K8sResource(
-            apiVersion="policy/v1beta1",
+            apiVersion="policy/v1",
             kind="PodDisruptionBudget",
             name="poddisruptionbudgets",
             namespaced=True,
-            url=f"{config.url}/apis/policy/v1beta1",
+            url=f"{config.url}/apis/policy/v1",
         ),
-        ("PodDisruptionBudget", "policy/v1beta1"): K8sResource(
-            apiVersion="policy/v1beta1",
+        ("PodDisruptionBudget", "policy/v1"): K8sResource(
+            apiVersion="policy/v1",
             kind="PodDisruptionBudget",
             name="poddisruptionbudgets",
             namespaced=True,
-            url=f"{config.url}/apis/policy/v1beta1",
+            url=f"{config.url}/apis/policy/v1",
         ),
         ("Role", ""): K8sResource(
             apiVersion="rbac.authorization.k8s.io/v1",
@@ -334,13 +285,6 @@ def k8s_apis(config: K8sConfig):
             namespaced=True,
             url=f"{config.url}/apis/rbac.authorization.k8s.io/v1",
         ),
-        ("Role", "rbac.authorization.k8s.io/v1beta1"): K8sResource(
-            apiVersion="rbac.authorization.k8s.io/v1beta1",
-            kind="Role",
-            name="roles",
-            namespaced=True,
-            url=f"{config.url}/apis/rbac.authorization.k8s.io/v1beta1",
-        ),
         ("RoleBinding", ""): K8sResource(
             apiVersion="rbac.authorization.k8s.io/v1",
             kind="RoleBinding",
@@ -354,13 +298,6 @@ def k8s_apis(config: K8sConfig):
             name="rolebindings",
             namespaced=True,
             url=f"{config.url}/apis/rbac.authorization.k8s.io/v1",
-        ),
-        ("RoleBinding", "rbac.authorization.k8s.io/v1beta1"): K8sResource(
-            apiVersion="rbac.authorization.k8s.io/v1beta1",
-            kind="RoleBinding",
-            name="rolebindings",
-            namespaced=True,
-            url=f"{config.url}/apis/rbac.authorization.k8s.io/v1beta1",
         ),
         ("Secret", ""): K8sResource(
             apiVersion="v1",
@@ -417,20 +354,6 @@ def k8s_apis(config: K8sConfig):
             name="statefulsets",
             namespaced=True,
             url=f"{config.url}/apis/apps/v1",
-        ),
-        ("StatefulSet", "apps/v1beta1"): K8sResource(
-            apiVersion="apps/v1beta1",
-            kind="StatefulSet",
-            name="statefulsets",
-            namespaced=True,
-            url=f"{config.url}/apis/apps/v1beta1",
-        ),
-        ("StatefulSet", "apps/v1beta2"): K8sResource(
-            apiVersion="apps/v1beta2",
-            kind="StatefulSet",
-            name="statefulsets",
-            namespaced=True,
-            url=f"{config.url}/apis/apps/v1beta2",
         ),
     }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -287,7 +287,7 @@ class TestMainGet:
             kubecontext=None,
             kubeconfig=Filepath("/tmp/kubeconfig-kind.yaml"),
             selectors=Selectors(
-                kinds={"Namespace", "HorizontalPodAutoscaler"},
+                kinds={"HorizontalPodAutoscaler"},
                 namespaces=["test-hpa"],
                 labels=[],
             ),
@@ -300,11 +300,10 @@ class TestMainGet:
         assert len(manifests) == 3
 
         # ---------------------------------------------------------------------
-        # Deploy the resources: one namespace with two HPAs in it. On will be
-        # deployed via `autoscaling/v1` the other via `autoscaling/v2beta2`.
+        # Deploy two HPAs into the same namespace. One HPA will use
+        # `autoscaling/v1` whereas the other uses `autoscaling/v2beta2`.
         # ---------------------------------------------------------------------
-        sh.kubectl("apply", "--kubeconfig", config.kubeconfig,
-                   "-f", str(man_path))
+        sh.kubectl("apply", "--kubeconfig", config.kubeconfig, "-f", str(man_path))
 
         # ---------------------------------------------------------------------
         # Sync all manifests. This must do nothing. In particular, it must not
@@ -436,7 +435,7 @@ class TestMainPlan:
             kubecontext=None,
             kubeconfig=Filepath("/tmp/kubeconfig-kind.yaml"),
             selectors=Selectors(
-                kinds={"Namespace", "HorizontalPodAutoscaler"},
+                kinds={"HorizontalPodAutoscaler"},
                 namespaces=["test-hpa"],
                 labels=[]),
         )

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -442,10 +442,10 @@ class TestUrlPathBuilder:
     def test_resource_namespace(self, integrationtest, k8sconfig):
         """Verify with a Namespace resource.
 
-        This one is a special case because it is not namespaced yet Square's
-        MetaManifest may specify a `namespace` which, in this one special case
-        refers to the namespace's actual name. This is a necessary
-        implementation detail to properly support the selectors.
+        This one is a special case because namespaces not themselves namespaced
+        yet Square's MetaManifest may specify one. This is a special case where
+        the `namespace` field refers to the actual name of the namespace. This
+        is a necessary implementation detail to properly support the selectors.
 
         """
         # Fixtures.
@@ -485,7 +485,8 @@ class TestUrlPathBuilder:
     def test_resource_clusterrole(self, integrationtest, k8sconfig):
         """Verify with a ClusterRole resource.
 
-        NOTE: this test is tailored to Kubernetes v1.16.
+        This is a basic test since ClusterRoles only exist as
+        rbac.authorization.k8s.io/v1 anymore.
 
         """
         # Fixtures.
@@ -650,7 +651,7 @@ class TestUrlPathBuilder:
 
         # Sanity check.
         kinds = {
-            # Standard resources that a v1.16 Kubernetes cluster always has.
+            # Some standard resources that every v1.24 Kubernetes cluster has.
             ('ClusterRole', 'rbac.authorization.k8s.io/v1'),
             ('ConfigMap', 'v1'),
             ('DaemonSet', 'apps/v1'),
@@ -729,8 +730,8 @@ class TestUrlPathBuilder:
             url=f"{config.url}/apis/mycrd.com/v1",
         )
 
-        # Verify default resource versions for a Deployment. This is specific
-        # to Kubernetes 1.16.
+        # Verify default resource versions for a Deployment. In 1.24 the
+        # default (and only) API version for Deployments is `apps/v1`.
         assert config.apis[("Deployment", "")].apiVersion == "apps/v1"
 
 

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -374,10 +374,9 @@ class TestUrlPathBuilder:
 
     @pytest.mark.parametrize("integrationtest", [False, True])
     def test_resource_hpa(self, integrationtest, k8sconfig):
-        """Verify with a HorizontalPodAutoscaler resource.
+        """Verify API version retrieval with a HorizontalPodAutoscaler.
 
-        This resource is available under four different API endpoints
-        (v1, v2, v2beta1 and v2beta2).
+        This resource is available as {v1, v2, v2beta1 and v2beta2}.
 
         NOTE: this test is tailored to Kubernetes v1.24.
 
@@ -403,7 +402,7 @@ class TestUrlPathBuilder:
         name = kind.lower() + "s"
 
         for src, expected in api_versions:
-            # A particular StatefulSet in a particular namespace.
+            # A particular HPA in a particular namespace.
             res, err = k8s.resource(config, MM(src, kind, "ns", "name"))
             assert not err
             assert res == K8sResource(
@@ -414,7 +413,7 @@ class TestUrlPathBuilder:
                 url=f"{config.url}/apis/{expected}/namespaces/ns/{name}/name",
             )
 
-            # All StatefulSets in all namespaces.
+            # All HPAs in all namespaces.
             res, err = k8s.resource(config, MM(src, kind, None, None))
             assert not err
             assert res == K8sResource(
@@ -425,7 +424,7 @@ class TestUrlPathBuilder:
                 url=f"{config.url}/apis/{expected}/{name}",
             )
 
-            # All StatefulSets in a particular namespace.
+            # All HPAs in a particular namespace.
             res, err = k8s.resource(config, MM(src, kind, "ns", ""))
             assert not err
             assert res == K8sResource(
@@ -436,7 +435,7 @@ class TestUrlPathBuilder:
                 url=f"{config.url}/apis/{expected}/namespaces/ns/{name}",
             )
 
-            # A particular StatefulSet in all namespaces -> Invalid.
+            # A particular HPA in all namespaces -> Invalid.
             assert k8s.resource(config, MM(src, kind, None, "name")) == err_resp
 
     @pytest.mark.parametrize("integrationtest", [False, True])

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -401,7 +401,6 @@ class TestUrlPathBuilder:
         name = kind.lower() + "s"
 
         for src, expected in api_versions:
-            print(src)
             # A particular StatefulSet in a particular namespace.
             res, err = k8s.resource(config, MM(src, kind, "ns", "name"))
             assert not err

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -652,11 +652,11 @@ class TestUrlPathBuilder:
         kinds = {
             # Standard resources that a v1.16 Kubernetes cluster always has.
             ('ClusterRole', 'rbac.authorization.k8s.io/v1'),
-            ('ClusterRole', 'rbac.authorization.k8s.io/v1beta1'),
             ('ConfigMap', 'v1'),
             ('DaemonSet', 'apps/v1'),
             ('Deployment', 'apps/v1'),
             ('HorizontalPodAutoscaler', 'autoscaling/v1'),
+            ('HorizontalPodAutoscaler', 'autoscaling/v2'),
             ('HorizontalPodAutoscaler', 'autoscaling/v2beta1'),
             ('HorizontalPodAutoscaler', 'autoscaling/v2beta2'),
             ('Pod', 'v1'),
@@ -712,12 +712,12 @@ class TestUrlPathBuilder:
             namespaced=True,
             url=f"{config.url}/apis/apps/v1",
         )
-        assert config.apis[("Ingress", "networking.k8s.io/v1beta1")] == K8sResource(
-            apiVersion="networking.k8s.io/v1beta1",
+        assert config.apis[("Ingress", "networking.k8s.io/v1")] == K8sResource(
+            apiVersion="networking.k8s.io/v1",
             kind="Ingress",
             name="ingresses",
             namespaced=True,
-            url=f"{config.url}/apis/networking.k8s.io/v1beta1",
+            url=f"{config.url}/apis/networking.k8s.io/v1",
         )
 
         # Verify our CRD.

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -322,9 +322,11 @@ class TestUrlPathBuilder:
 
     @pytest.mark.parametrize("integrationtest", [False, True])
     def test_resource_service(self, integrationtest, k8sconfig):
-        """Verify with a Service resource.
+        """Function must query the correct version of the API endpoint.
 
-        NOTE: this test is tailored to Kubernetes v1.16.
+        This test uses a Service which is available as part of the core API.
+
+        NOTE: this test is tailored to Kubernetes v1.24.
 
         """
         # Fixtures.
@@ -441,10 +443,10 @@ class TestUrlPathBuilder:
     def test_resource_namespace(self, integrationtest, k8sconfig):
         """Verify with a Namespace resource.
 
-        This one is a special case because it is not namespaced but Square's
-        MetaManifest may specify a `namespace` for them, which refers to their
-        actual name. This is a necessary implementation detail to properly
-        support the selectors.
+        This one is a special case because it is not namespaced yet Square's
+        MetaManifest may specify a `namespace` which, in this one special case
+        refers to the namespace's actual name. This is a necessary
+        implementation detail to properly support the selectors.
 
         """
         # Fixtures.

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -376,10 +376,10 @@ class TestUrlPathBuilder:
     def test_resource_hpa(self, integrationtest, k8sconfig):
         """Verify with a HorizontalPodAutoscaler resource.
 
-        This resource is available under three different API endpoints
-        (v1, v2beta1 and v2beta2).
+        This resource is available under four different API endpoints
+        (v1, v2, v2beta1 and v2beta2).
 
-        NOTE: this test is tailored to Kubernetes v1.16.
+        NOTE: this test is tailored to Kubernetes v1.24.
 
         """
         config = self.k8sconfig(integrationtest, k8sconfig)
@@ -395,7 +395,7 @@ class TestUrlPathBuilder:
             ("autoscaling/v2beta2", "autoscaling/v2beta2"),
 
             # Function must automatically determine the latest version of the resource.
-            ("", "autoscaling/v1"),
+            ("", "autoscaling/v2"),
         ]
 
         # Convenience.

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -373,7 +373,7 @@ class TestUrlPathBuilder:
             assert k8s.resource(k8sconfig, MM(src, "Service", None, "name")) == err_resp
 
     @pytest.mark.parametrize("integrationtest", [False, True])
-    def test_resource_statefulset(self, integrationtest, k8sconfig):
+    def test_resource_hpa(self, integrationtest, k8sconfig):
         """Verify with a HorizontalPodAutoscaler resource.
 
         This resource is available under three different API endpoints


### PR DESCRIPTION
The upgrade to a more recent K8s version does not affect Square itself.

However, it does affect tests that assume certain API versions to (not) exist. Furthermore, some example manifests that were written for older cluster versions (eg CRDs or ingresses) are no longer valid in newer K8s version.

This PR upgrades all the manifests, tests and helpers to make them compatible with K8s 1.24.