### PR TITLE
Bump version: 1.2.0 → 1.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.3.0
 commit = True
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![](https://img.shields.io/badge/license-Apache%202-blue.svg)]()
 [![](https://img.shields.io/badge/python-3.10+-blue.svg)]()
-[![](https://img.shields.io/badge/latest-v1.2.0-blue.svg)]()
+[![](https://img.shields.io/badge/latest-v1.3.0-blue.svg)]()
 [![](https://github.com/olitheolix/square/workflows/build/badge.svg)]()
 [![](https://img.shields.io/codecov/c/github/olitheolix/square.svg?style=flat)]()
 
@@ -18,13 +18,13 @@ install it into a Python 3.10+ environment with `pip install kubernetes-square
 --upgrade`.
 ```console
 foo@bar:~$ square version
-1.2.0
+1.3.0
 ```
 
 You may also use a pre-built Docker image:
 ```console
-foo@bar:~$ docker run -ti --rm olitheolix/square:v1.2.0 version
-1.2.0
+foo@bar:~$ docker run -ti --rm olitheolix/square:v1.3.0 version
+1.3.0
 ```
 
 # Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kubernetes-square"
-version = "1.2.0"
+version = "1.3.0"
 description = ""
 authors = ["Oliver Nagy <olitheolix@gmail.com>"]
 packages = [

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -4,7 +4,7 @@ import sys
 from . import square
 from .cfgfile import load
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
All builds are now based on Python 3.10. No changes to Square itself.