### PR TITLE
GitHub actions install Square

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -97,3 +97,27 @@ jobs:
         run: |
           pytest --cov=square
           pipenv run mypy ./
+
+  # ----------------------------------------------------------------------------
+  # Use Poetry and PIP to build and install Square on recent Python versions.
+  # ----------------------------------------------------------------------------
+  python-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Square With Python 3.10
+        run: |
+          # Install Poetry and build the Python package.
+          pip install poetry==1.1.13
+          poetry build
+
+          # Install the package. The following shell magic expands to
+          # eg `pip install dist/kubernetes-square-1.3.2.tar.gz`
+          pip install "dist/kubernetes-square-`poetry version -s`.tar.gz"
+
+          # Invoke Square to ensure it runs.
+          square version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,14 +7,19 @@ on:
     branches: [ master ]
 
 jobs:
+  # ----------------------------------------------------------------------------
+  # Start KinD cluster and run unit and integration tests.
+  # Upload the coverage report to CodeCov.
+  # ----------------------------------------------------------------------------
   linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
       - name: Download Kubernetes Utilities
         run: |
           mkdir ~/bin
@@ -52,13 +57,15 @@ jobs:
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: true
+
+  # ----------------------------------------------------------------------------
+  # Run only the unit tests on Windows because we cannot run KinD there.
+  # ----------------------------------------------------------------------------
   windows:
     runs-on: windows-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           architecture: 'x64'
@@ -71,12 +78,14 @@ jobs:
         run: |
           pytest --cov=square --ignore=tests/test_integration.py
 
+  # ----------------------------------------------------------------------------
+  # Run only the unit tests on OSX because we cannot run KinD there.
+  # ----------------------------------------------------------------------------
   macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install dependencies


### PR DESCRIPTION
Ensure Square works on Python 3.10.

This PR adds a dedicated Github Action to
- Build `Square` with `Poetry`.
- Install `Square` with `pip` into a Python 3.10 environment.
- Verify that `square version` runs without errors.