### PR TITLE
Improve Resource Kind Selectors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ norecursedirs = .git
 
 
 [mypy]
+plugins = pydantic.mypy
+
 ignore_missing_imports=true
 allow_redefinition=true
 show_error_codes = True

--- a/square/cfgfile.py
+++ b/square/cfgfile.py
@@ -117,13 +117,13 @@ def load(fname: Filepath) -> Tuple[Config, bool]:
         logit.error(msg)
         return err_resp
 
-    if not isinstance(raw, dict):
-        logit.error(f"Config file <{fname}> has invalid structure")
-        return err_resp
-
     # Parse the configuration into `ConfigFile` structure.
     try:
-        cfg = Config(**raw)
+        cfg = Config.model_validate(raw)
+
+        # Explicitly access the computed `_kinds_names` attribute because
+        # Pydantic will not compute it until it is accessed.
+        cfg.selectors._kinds_names
     except (pydantic.ValidationError, TypeError) as e:
         logit.error(f"Schema is invalid: {e}")
         return err_resp

--- a/square/cfgfile.py
+++ b/square/cfgfile.py
@@ -124,6 +124,7 @@ def load(fname: Filepath) -> Tuple[Config, bool]:
         # Explicitly access the computed `_kinds_names` attribute because
         # Pydantic will not compute it until it is accessed.
         cfg.selectors._kinds_names
+        cfg.selectors._kinds_only
     except (pydantic.ValidationError, TypeError) as e:
         logit.error(f"Schema is invalid: {e}")
         return err_resp

--- a/square/cfgfile.py
+++ b/square/cfgfile.py
@@ -137,6 +137,4 @@ def load(fname: Filepath) -> Tuple[Config, bool]:
     # Ensure the path is an absolute path.
     cfg.folder = fname.parent.absolute() / cfg.folder
 
-    # Convert the list to a set. No functional reason.
-    cfg.selectors.kinds = set(cfg.selectors.kinds)
     return cfg, False

--- a/square/manio.py
+++ b/square/manio.py
@@ -73,8 +73,8 @@ def select(manifest: dict, selectors: Selectors) -> bool:
         bool: `True` iff the resource matches all selectors.
 
     """
-    # "kinds" cannot be an empty list or `None`.
-    if not selectors.kinds:
+    # The "kinds" selector must be non-empty.
+    if len(selectors.kinds) == 0:
         logit.error(f"BUG: selector must specify a `kind`: {selectors}")
         return False
 
@@ -94,9 +94,9 @@ def select(manifest: dict, selectors: Selectors) -> bool:
     # Furthermore, we *never* mess with `default-token-*` Secrets or the
     # `default` service account. K8s automatically creates them in every new
     # namespace. We can thus never "restore" them with Square because the plan
-    # says to create them yet once Square created the namespace they also
-    # already exist and can only be patched. As a result, Square would abort
-    # unexpectedly.
+    # would create them yet once Square created the associated namespace the
+    # service account already exist and can only be patched, not created
+    # anymore. As a result, Square would abort unexpectedly.
     ns = manifest.get("metadata", {}).get("namespace", None)
     if kind == "Namespace":
         ns = manifest.get("metadata", {}).get("name", None)
@@ -111,7 +111,7 @@ def select(manifest: dict, selectors: Selectors) -> bool:
     else:
         pass
 
-    # Abort if this manifest does not have the KIND we are looking for.
+    # Abort if this manifest does not have a KIND that matches the selector.
     if kind not in selectors.kinds:
         logit.debug(f"Kind {kind} does not match selector {selectors.kinds}")
         return False

--- a/square/square.py
+++ b/square/square.py
@@ -39,8 +39,8 @@ def translate_resource_kinds(cfg: Config, k8sconfig: K8sConfig) -> Config:
     # Avoid side effects to the original `cfg`.
     cfg = copy.deepcopy(cfg)
 
-    # Translate the possibly colloquial names to their canonical K8s names. Use
-    # the original name if we cannot find the canonical name.
+    # Translate the shorthand names to their canonical K8s names. Use the
+    # original name if we cannot find a canonical name for it.
     kinds = {k8sconfig.short2kind.get(_.lower(), _) for _ in cfg.selectors.kinds}
     priorities = [k8sconfig.short2kind.get(_.lower(), _) for _ in cfg.priorities]
 
@@ -780,10 +780,11 @@ def get_resources(cfg: Config) -> bool:
         cfg = translate_resource_kinds(cfg, k8sconfig)
 
         # Use a wildcard Selector to ensure `manio.load` will read _all_ local
-        # manifests. This will allow `manio.sync` to modify the ones specified by
-        # the `selector` argument only, delete all the local manifests, and then
-        # write the new ones. This logic will ensure we never have stale manifests.
-        # Refer to `manio.save_files` for details and how `manio.save` uses it.
+        # manifests. This will allow `manio.sync` to modify the ones specified
+        # by the `selector` argument only, delete all the local manifests and
+        # then create the new ones. This logic will ensure we never have stale
+        # manifests. Refer to `manio.save_files` for details and how
+        # `manio.save` uses it.
         load_selectors = Selectors(kinds=k8sconfig.kinds, labels=[], namespaces=[])
 
         # Load manifests from local files.

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,0 +1,102 @@
+import pytest
+
+from square.dtypes import KindName, Selectors
+
+
+class TestSelectors:
+    def test_Selectors_ok(self):
+        """Valid set of K8s kinds for Selectors.
+
+        These tests all populate the model via the constructor.
+        """
+        # Defaults.
+        sel = Selectors()
+        assert sel.kinds == sel._kinds_only == set()
+        assert sel._kinds_names == []
+
+        # Verify the three valid cases to specify a resource kind.
+        kinds = {"pod", "namespace/", "deploy/app1"}
+        sel = Selectors(kinds=kinds)
+        assert sel.kinds == kinds
+
+        # Must not include the `deploy` because it specifies a specific
+        # resource instead of just a generic KIND.
+        assert sel._kinds_only == {"pod", "namespace"}
+
+        # The unpacked `_kinds_names` must be in alphabetical order.
+        assert sel._kinds_names == [
+            KindName(kind="deploy", name="app1"),
+            KindName(kind="namespace", name=""),
+            KindName(kind="pod", name=""),
+        ]
+
+    def test_Selectors_kinds_only(self):
+        """Must extract the correct set of K8s resource KINDS."""
+        # Defaults.
+        sel = Selectors()
+        assert sel.kinds == sel._kinds_only == set()
+        assert sel._kinds_names == []
+
+        # Select all pods, a specific pod and a specific deployment. The model
+        # must correctly unpack the resource KINDS, but most notably the only
+        # generic resource kind is the `Pod` because `pod/app1` and
+        # `deploy/app2` specify one explicit resource instead of an entire KIND.
+        kinds = {"pod", "pod/app1", "deploy/app2"}
+        sel = Selectors(kinds=kinds)
+        assert sel.kinds == kinds
+        assert sel._kinds_only == {"pod"}
+
+        # The unpacked `_kinds_names` must be in alphabetical order.
+        assert sel._kinds_names == [
+            KindName(kind="deploy", name="app2"),
+            KindName(kind="pod", name=""),
+            KindName(kind="pod", name="app1"),
+        ]
+
+    def test_Selectors_modify_ok(self):
+        """Modify the selectors via attribute assignment."""
+        # Create default model.
+        sel = Selectors()
+        assert sel.kinds == set() and sel._kinds_names == []
+
+        # Assign to the `kinds` attribute directly. This must also update the
+        # `_kinds_names` attribute.
+        sel.kinds = {"x/y"}
+        assert sel.kinds == {"x/y"}
+        assert sel._kinds_names == [KindName(kind="x", name="y")]
+
+        # Use set methods like to `clear` and `update`. This must update
+        # the `_kinds_names` attribute as well.
+        sel.kinds.clear()
+        sel.kinds.update({"a/b"})
+        assert sel.kinds == {"a/b"}
+        assert sel._kinds_names == [KindName(kind="a", name="b")]
+
+    def test_Selectors_duplicates(self):
+        """Must remove duplicate kinds after removing white space."""
+        # These all specify the exact same resource kind and the model must be
+        # smart enough to collapse them into a single one.
+        sel = Selectors(kinds={"foo/bar", " foo/bar", "foo/bar ", " foo/bar "})
+        assert sel.kinds == {"foo/bar"}
+        assert sel._kinds_names == [KindName(kind="foo", name="bar")]
+
+        sel = Selectors(kinds={"foo/", " foo/", "foo/ ", " foo/ "})
+        assert sel.kinds == {"foo/"}
+        assert sel._kinds_names == [KindName(kind="foo", name="")]
+
+        sel = Selectors(kinds={"foo", " foo", "foo ", " foo "})
+        assert sel.kinds == {"foo"}
+        assert sel._kinds_names == [KindName(kind="foo", name="")]
+
+    def test_Selectors_err(self):
+        """Various error scenarios of invalid resource kinds."""
+        # Various cases of invalid "kind" names.
+        invalid_kinds = [
+            "", "/", "/bar",
+            " /", "/ ", " / "
+            "foo / bar", "foo/ bar", "foo /bar"
+        ]
+
+        for kind in invalid_kinds:
+            with pytest.raises(ValueError):
+                Selectors(kinds={kind})._kinds_names

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -34,13 +34,9 @@ class TestBasic:
             folder=tmp_path,
             kubecontext="ctx",
             kubeconfig=tmp_path,
-            selectors=Selectors(
-                kinds=set(),
-                namespaces=[],
-                labels=[]
-            ),
+            selectors=Selectors(),
             priorities=list(DEFAULT_PRIORITIES),
-            groupby=GroupBy(label="", order=[]),
+            groupby=GroupBy(),
             filters={},
         )
 
@@ -110,13 +106,9 @@ class TestBasic:
             folder=Filepath('/tmp'),
             kubeconfig=Filepath(),
             kubecontext=None,
-            selectors=Selectors(
-                kinds={"svc", 'DEPLOYMENT', "Secret"},
-                namespaces=['default'],
-                labels=["app=square", "foo=bar"],
-            ),
-            groupby=GroupBy(label="", order=[]),
+            groupby=GroupBy(),
             priorities=["ns", "DEPLOYMENT"],
+            selectors=Selectors(kinds={"svc", 'DEPLOYMENT', "Secret"}),
         )
 
         # Convert the resource names to their correct K8s kind.
@@ -136,7 +128,7 @@ class TestBasic:
 
     def test_valid_label(self):
         """Test label values (not their key names)."""
-        # A specific example of a valid label that trigger a bug once.
+        # A specific example of a valid label that triggered a bug once.
         assert sq.valid_label("dh/repo=pd-devops-charts")
 
         # Valid specimen.


### PR DESCRIPTION
The `Selector` model now derives the additional fields `_kinds_names` and `_kinds_only`. These contain parsed version of the K8s resource kinds. This will furnish a more fine grained selection of resource in a followup PR so that users can target a specific single resource, eg `Service/foo`.