### PR TITLE
Fold multi-line strings in YAML output.

### DIFF
--- a/integration-test-cluster/square-tests-2.yaml
+++ b/integration-test-cluster/square-tests-2.yaml
@@ -43,6 +43,21 @@ metadata:
 
 ---
 
+apiVersion: v1
+data:
+  comment: |
+    This is a
+    multi-line comment that
+    spans three rows.
+kind: ConfigMap
+metadata:
+  name: multiline-1
+  namespace: square-tests-2
+  labels:
+    app: demoapp-1
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/square/manio.py
+++ b/square/manio.py
@@ -16,26 +16,11 @@ from square.dtypes import (
     Config, Filepath, Filters, FiltersKind, GroupBy, K8sConfig, K8sResource,
     KindName, LocalManifestLists, MetaManifest, Selectors, SquareManifests,
 )
+from square.yaml_io import Dumper, Loader
 
 # Convenience: global logger instance to avoid repetitive code.
 logit = logging.getLogger("square")
 DotDict = square.dotdict.DotDict
-
-
-# Use the fast CSafeLoader/CSafeDumper from the LibYAML C library if they are
-# available on the host, otherwise fall back to the slow Python loader/dumper.
-# NOTE: this import is excluded from the coverage report since it is difficult
-#       to write a meaningful test around a library import that may or may not
-#       exist on the host. I deem this acceptable in this case because it is a
-#       widely used snippet and devoid of logic.
-try:                                 # codecov-skip
-    from yaml import (  # type: ignore
-        CSafeDumper as Dumper, CSafeLoader as Loader,
-    )
-    logit.debug("Using LibYAML C library")
-except ImportError:                  # codecov-skip
-    from yaml import Dumper, Loader  # type: ignore
-    logit.debug("Using Python YAML library")
 
 
 def make_meta(manifest: dict) -> MetaManifest:

--- a/square/yaml_io.py
+++ b/square/yaml_io.py
@@ -1,0 +1,56 @@
+"""Setup YAML to use fast loaders if possible, and fold multi-line strings.
+
+This file does not really contain any logic as such. Its sole purpose is setup
+the YAML library such that it uses the fast CSafeLoader/CSafeDumper from the
+LibYAML C library if they are available on the host, or fall back to the slow
+Python loader/dumper if not.
+
+Furthermore, it will configure the Dumper to use the "|" syntax for multi-line
+strings. This makes ConfigMaps in particular more readable.
+
+To make use of this, the other modules can simply use:
+
+   from yaml_io import Loader, Dumper
+
+"""
+import logging
+
+# Convenience: global logger instance to avoid repetitive code.
+logit = logging.getLogger("square")
+
+# ----------------------------------------------------------------------------
+# NOTE: this import is excluded from the coverage report since it is difficult
+#       to write a meaningful test around a library import that may or may not
+#       exist on the host. I deem this acceptable in this case because it is a
+#       widely used snippet and devoid of logic.
+# ----------------------------------------------------------------------------
+try:                                 # codecov-skip
+    from yaml import (  # type: ignore
+        CSafeDumper as Dumper, CSafeLoader as Loader,
+    )
+    logit.debug("Using LibYAML C library")
+except ImportError:                  # codecov-skip
+    from yaml import Dumper, Loader  # type: ignore
+    logit.debug("Using Python YAML library")
+
+
+def fold_yaml_strings(dumper, data):
+    """
+    Fold all YAML strings that contain a new-line, ie use the `|` notation, eg
+
+    foo: |
+      this is
+      a multi-line string.
+
+    """
+    if '\n' in data:
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+
+# Install the new string converter into the Dumper.
+Dumper.add_representer(str, fold_yaml_strings)
+
+# We must now have a `Dumper` and `Loader` that other modules can import.
+assert Loader is not None
+assert Dumper is not None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -350,7 +350,7 @@ class TestKindName:
         )
         plan, err = square.plan(config)
         assert not err
-        assert len(plan.create) == len(plan.patch) == 0 and len(plan.delete) == 7
+        assert len(plan.create) == len(plan.patch) == 0 and len(plan.delete) == 8
 
         # ----------------------------------------------------------------------
         # Must find 3 Configmaps in "square-tests-1".


### PR DESCRIPTION
Use the pipe `|` operator to fold mult-line strings when writing YAML files.

This is a quality of life improvement to make eg configurations in `ConfigMaps` easier to read and modify.