### PR TITLE
Improve defaults in ".square.yaml" file.

### DIFF
--- a/resources/defaultconfig.yaml
+++ b/resources/defaultconfig.yaml
@@ -6,7 +6,7 @@ kubeconfig: /path/to/kubeconfig
 kubecontext: null
 
 # Where Square will read and write manifests.
-folder: .
+folder: manifests/
 
 
 # -----------------------------------------------------------------------------
@@ -35,7 +35,7 @@ selectors:
     - StatefulSet
 
   # Target these namespaces. Use an empty list to target all.
-  namespaces: ["default"]
+  namespaces: []
 
   # Example: ["app=square", "foo=bar"]. Use an empty list to ignore labels.
   labels: []

--- a/square/main.py
+++ b/square/main.py
@@ -394,7 +394,7 @@ def main() -> int:
         print(
             f"Created configuration file <{fname}>.\n"
             "Please open the file in an editor and adjust the values, most notably "
-            "<kubeconfig>, <kubecontext>, <folder> and <selectors.labels>."
+            "`kubeconfig` and `selectors.[kinds | namespaces | labels]`."
         )
         return 0
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,9 +48,9 @@ def fname_param_config(tmp_path) -> Generator[
 
     # We will "abuse" the `kubecontext` field to indicate that this is our mock
     # ".square.yaml". We will also replace the default path with a custom one
-    # to avoid an ambiguity with the default value of "." for the folder.
+    # to avoid ambiguity with the default value of "manifests/" for the folder.
     ref["kubecontext"] = "dot-square"
-    assert ref["folder"] == "."
+    assert ref["folder"] == "manifests/"
     ref["folder"] = "foo/bar"
     fname_square.write_text(yaml.dump(ref))
     del ref
@@ -84,7 +84,7 @@ def fname_param_config(tmp_path) -> Generator[
         folder=".",
         kinds=DEFAULT_PRIORITIES,
         labels=[],
-        namespaces=["default"],
+        namespaces=[],
         kubecontext=None,
         groupby=["ns", "label=app", "kind"],
         priorities=DEFAULT_PRIORITIES,


### PR DESCRIPTION
The default `.square.yaml` now targets all Namespaces by default.

Furthermore, the default folder for  the manifests is now `manifests/` instead of `.`.