### PR TITLE
bugfix(conf): load_eks_config does not expect command arguments anymore.

### DIFF
--- a/square/k8s.py
+++ b/square/k8s.py
@@ -230,7 +230,7 @@ def load_eks_config(
     try:
         ssl_ca_cert_data = base64.b64decode(cluster["certificate-authority-data"])
         cmd = user["exec"]["command"]
-        args = user["exec"]["args"]
+        args = user["exec"].get("args", [])
         env_kubeconf = user["exec"].get("env", [])
     except KeyError:
         logit.debug(f"Context {context} in <{fname}> is not an EKS config")

--- a/tests/support/kubeconf.yaml
+++ b/tests/support/kubeconf.yaml
@@ -22,6 +22,10 @@ contexts:
     user: aws
   name: eks
 - context:
+    cluster: clustername-eks
+    user: aws-noargs
+  name: eks-noargs
+- context:
     cluster: clustername-gke
     user: gke_foo-bar-123456_australia-southeast1-foobar
   name: gke
@@ -56,6 +60,16 @@ users:
       - token
       - -i
       - eks-cluster-name
+      command: aws-iam-authenticator
+      env:
+        - name: foo1
+          value: bar1
+        - name: foo2
+          value: bar2
+- name: aws-noargs
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws-iam-authenticator
       env:
         - name: foo1


### PR DESCRIPTION
If the Kubeconfig file specifies an external command to create the Kubernetes access token, that command may or may not have arguments. Square has so far assumed that the `args` field in the Kubeconfig file is always present even though it is actually optional. This PR fixes that.