### PR TITLE
Try authenticator first

### DIFF
--- a/square/k8s.py
+++ b/square/k8s.py
@@ -161,7 +161,7 @@ def load_authenticator_config(fname: Filepath,
         args = user["exec"].get("args", [])
         env_kubeconf = user["exec"].get("env", [])
     except KeyError:
-        logit.debug(f"Context {context} in <{fname}> is not an EKS config")
+        logit.debug(f"Context {context} in <{fname}> does not use authenticator app")
         return (K8sConfig(), True)
 
     # Convert a None value (valid value in YAML) to an empty list of env vars.
@@ -176,7 +176,7 @@ def load_authenticator_config(fname: Filepath,
     cmd_args = [cmd] + args
     env_kubeconf = {_["name"]: _["value"] for _ in env_kubeconf}
     env.update(env_kubeconf)
-    logit.debug(f"Requesting EKS certificate: {cmd_args} with envs: {env_kubeconf}")
+    logit.debug(f"Authenticator app: {cmd_args} with envs: {env_kubeconf}")
 
     # Pre-format the command for the log message.
     log_cmd = (
@@ -200,7 +200,7 @@ def load_authenticator_config(fname: Filepath,
         return (K8sConfig(), True)
 
     # Return the Kubernetes access configuration.
-    logit.info("Assuming EKS cluster.")
+    logit.info("Assuming generic cluster.")
     return K8sConfig(
         url=cluster["server"],
         token=token,
@@ -319,7 +319,7 @@ def load_auto_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig
 
     1) `load_incluster_config`
     1) `load_minikube_config`
-    2) `load_eks_config`
+    2) `load_authenticator_config`
 
     Inputs:
         fname: Filepath
@@ -349,7 +349,7 @@ def load_auto_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig
     conf, err = load_authenticator_config(fname, context)
     if not err:
         return conf, False
-    logit.debug("EKS config failed")
+    logit.debug("Authenticator config failed")
 
     logit.error(f"Could not find a valid configuration in <{fname}>")
     return (K8sConfig(), True)

--- a/square/k8s.py
+++ b/square/k8s.py
@@ -128,10 +128,7 @@ def load_incluster_config(
     ), False
 
 
-def load_eks_config(
-        fname: Filepath,
-        context: Optional[str],
-        _: bool = False) -> Tuple[K8sConfig, bool]:
+def load_eks_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig, bool]:
     """Return K8s access config for EKS cluster described in `kubeconfig`.
 
     Returns None if `kubeconfig` does not exist or could not be parsed.
@@ -141,9 +138,6 @@ def load_eks_config(
             Path to kubeconfig file, eg "~/.kube/config.yaml"
         context: Optional[str]
             Kubeconf context. Use `None` to select the default context.
-        disable_warnings: bool (unused)
-            Not used. It only exists for consistency with `load_gke_config` to
-            make those functions generic.
 
     Returns:
         Config
@@ -316,10 +310,7 @@ def load_kind_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig
         return (K8sConfig(), True)
 
 
-def load_auto_config(
-        fname: Filepath,
-        context: Optional[str],
-        disable_warnings: bool = False) -> Tuple[K8sConfig, bool]:
+def load_auto_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig, bool]:
     """Automagically find and load the correct K8s configuration.
 
     This function will load several possible configuration options and returns
@@ -354,7 +345,7 @@ def load_auto_config(
         return conf, False
     logit.debug("KIND config failed")
 
-    conf, err = load_eks_config(fname, context, disable_warnings)
+    conf, err = load_eks_config(fname, context)
     if not err:
         return conf, False
     logit.debug("EKS config failed")
@@ -654,7 +645,7 @@ def cluster_config(
     kubeconfig = kubeconfig.expanduser()
     try:
         # Parse Kubeconfig file.
-        k8sconfig, err = load_auto_config(kubeconfig, context, disable_warnings=True)
+        k8sconfig, err = load_auto_config(kubeconfig, context)
         assert not err
 
         # Configure HttpX session.

--- a/square/k8s.py
+++ b/square/k8s.py
@@ -128,8 +128,9 @@ def load_incluster_config(
     ), False
 
 
-def load_eks_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig, bool]:
-    """Return K8s access config for EKS cluster described in `kubeconfig`.
+def load_authenticator_config(fname: Filepath,
+                              context: Optional[str]) -> Tuple[K8sConfig, bool]:
+    """Return K8s config based on authenticator app specified in `kubeconfig`.
 
     Returns None if `kubeconfig` does not exist or could not be parsed.
 
@@ -345,7 +346,7 @@ def load_auto_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig
         return conf, False
     logit.debug("KIND config failed")
 
-    conf, err = load_eks_config(fname, context)
+    conf, err = load_authenticator_config(fname, context)
     if not err:
         return conf, False
     logit.debug("EKS config failed")

--- a/square/k8s.py
+++ b/square/k8s.py
@@ -318,8 +318,9 @@ def load_auto_config(fname: Filepath, context: Optional[str]) -> Tuple[K8sConfig
     the first one with a match. The order is as follows:
 
     1) `load_incluster_config`
-    1) `load_minikube_config`
-    2) `load_authenticator_config`
+    2) `load_minikube_config`
+    3) `load_kind_config`
+    4) `load_authenticator_config`
 
     Inputs:
         fname: Filepath

--- a/tests/support/kubeconf.yaml
+++ b/tests/support/kubeconf.yaml
@@ -1,58 +1,72 @@
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: Y2EuY2VydAo= # Base64 encoded "ca.crt"
-    server: https://1.2.3.4
-  name: clustername-gke
-- cluster:
     certificate-authority: ca.crt
     server: https://192.168.0.177:8443
-  name: clustername-minikube
-- cluster:
-    certificate-authority-data: Y2EuY2VydAo= # Base64 encoded "ca.crt"
-    server: https://5.6.7.8
-  name: clustername-eks
+  name: minikube
 - cluster:
     certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwdGFXNXAKYTNWaVpVTkJNQjRYRFRFNU1EVXdNakF6TXpjeU1sb1hEVEk1TURRek1EQXpNemN5TWxvd0ZURVRNQkVHQTFVRQpBeE1LYldsdWFXdDFZbVZEUVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT2tECkllNS9ZenhzOWVGeG1NZnZJWi9hQ2RFSkFva3BDc2wwVG56cXVUbW9maUVQQ0xoT21mMW1lcENZbkZDazdWQkcKR25pMjFqNUxyUmNDRGZRejJ3a0JhMkZYQTl3dTNTblliSVdjNlZTZS9YUTFDVDdLVlVUSDRieExlL0MxU01kZQprZUdkUU51OHNJNW1Dbmd4OHJkQ1Q1QUJCRitjRTFsV2ZJVHludEdTTEgwNWJKekZ4RkMwT0VGMFFHdlFxaTFBClFqWUx5MEpvM3pjdGVxWWNMT21aNHNuRm5JUnhsRnh1bzllR0ptKzdOeTV1aUV3QnFDSEN2dUI3SFQwaUNvdEsKRmxoazhGN2p5VG9lc281c0lOWjdQVWdNZHUvTE54R1N1Yk1JV0tJWnY1UlUvVVpKSnF3NUo3ZmhxUFlveHV6MwpVbnNLaW10TjdFdmNWeUo0N0Q4Q0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUIwR0ExVWRKUVFXCk1CUUdDQ3NHQVFVRkJ3TUNCZ2dyQmdFRkJRY0RBVEFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFCQWNVRHBjNEZnQlBJZ0xJa2lsTWNiQi9oRkdJR2orcnBGMlpaVVEzSTByYnNocjlQTwpiOHY5cVZOUE43bnZzNWF6Wk1KSmpxS25XQXRwY2FXc3NqUThDRmYydit3SnNnNVVSdERxTk56Sy9jWUgrUmlNCjlmTDlyMnZRVTA1SWR3T3JzdzVvRmI0MDRGdWoxRVRQYjNXMGJabFdYcTdEOHpITmF4RnFNUnFRbGR4ckI5Y3MKY29kL2V0aTFsLzhHSXdSYkZkNGtackhlYWdFa3J5aVROMElTeFJGMitKdkc5ZDg5aHQyeGZKalpPbHllWU1ZdAovOHJ1dUV6KzhlUXhiRHlNVGZBS3lFZEJHTGNBZHFrVkMwUXdJMisySG83a2tMWm5reXVKcWJXTzZmTnFiU01VCmczS1pOUlU1ekFub0t3czJrdjRBZE5SV1YzNXI4dkFOVXkwdwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
     server: https://localhost:8443
   name: kind
+- cluster:
+    certificate-authority-data: Y2EuY2VydAo= # Base64 encoded "ca.crt"
+    server: https://aks.com
+  name: aks
+- cluster:
+    certificate-authority-data: Y2EuY2VydAo= # Base64 encoded "ca.crt"
+    server: https://eks.com
+  name: eks
+- cluster:
+    certificate-authority-data: Y2EuY2VydAo= # Base64 encoded "ca.crt"
+    server: https://gke.com
+  name: gke
 contexts:
 - context:
-    cluster: clustername-eks
-    user: aws
-  name: eks
-- context:
-    cluster: clustername-eks
-    user: aws-noargs
-  name: eks-noargs
-- context:
-    cluster: clustername-gke
-    user: gke_foo-bar-123456_australia-southeast1-foobar
-  name: gke
-- context:
-    cluster: clustername-minikube
+    cluster: minikube
     user: minikube
   name: minikube
 - context:
     cluster: kind
-    user: kind-admin
+    user: kind
   name: kind
+- context:
+    cluster: aks
+    user: aks
+  name: aks
+- context:
+    cluster: eks
+    user: eks
+  name: eks
+- context:
+    cluster: gke
+    user: gke
+  name: gke
 current-context: minikube
 kind: Config
 preferences: {}
 users:
-- name: gke_foo-bar-123456_australia-southeast1-foobar
+- name: minikube
   user:
-    auth-provider:
-      config:
-        access-token: encrypted-access-token
-        cmd-args: config config-helper --format=json
-        cmd-path: /usr/bin/gcloud
-        expiry: 2019-01-14T02:48:51Z
-        expiry-key: '{.credential.token_expiry}'
-        token-key: '{.credential.access_token}'
-      name: gcp
-- name: aws
+    client-certificate: client.crt
+    client-key: client.key
+- name: kind
+  user:
+    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM4akNDQWRxZ0F3SUJBZ0lJYW05RGQ3eU5kZHd3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2JXbHVhV3QxWW1WRFFUQWVGdzB4T1RBMU1ESXdNek0zTWpKYUZ3MHlNREExTURJd016TTNORFZhTURReApGekFWQmdOVkJBb1REbk41YzNSbGJUcHRZWE4wWlhKek1Sa3dGd1lEVlFRREV4QnJkV0psY201bGRHVnpMV0ZrCmJXbHVNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXBXVDhxZjZkejI4NUduVm4KRjZoTmdjMmZuNFhWRG9oTlRLYk5JaGxneG1aRkZnSXp0K1hZSmhDRXZBNEorT21HNXhHS1dDc0JYS3kweEZxRwp0bFM1K2xzZkFaN3psMUNOWDZ3T296bHFKblFhdnNLVHFzdVQ2MUw5QXcwMlM0VFJJY2JkQktOb3lRVTluRUpkCi9ZeFQwZnFFblFpeXljQWQzY0ZtZnA0WWJjajBZNGIyVmFNK2JSbDBocm5NcnJnOFViM3hXek93YlhOQlRUcnoKZHNZMnRkd3dBTFJjNFFmY2llZDhObEpLMFJrOTZFK2cxQnJZbE9ZeDVvSUtsUjNNVldvamhCZDdjWGo5OHZDdQpuNlgyeHF6aFozZ0JQQXFxVXVEeU1wakxvS29vODY4LzVseEoyZ25SSG9Ed3U4TFZuS3lsKzFrSTRoWFJYb29rCndSSHU3UUlEQVFBQm95Y3dKVEFPQmdOVkhROEJBZjhFQkFNQ0JhQXdFd1lEVlIwbEJBd3dDZ1lJS3dZQkJRVUgKQXdJd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFMcVJkUW9IYWJrZktzQVdLWEVqdTNRT2hxeWJPN1UwcGVkMQpDaTFoNE1xNE1POWRDM3J5b3BwTmp3ZjFlOUQyNElUREcyLzdVYkRFdkovNlhoYVFGRDM5eTI4Ump5MVlZNlUyClRSSUZXVEVRdjB3blN1elUyVGJpSXpZUU1BVlIwNjh6RUd4Q2NDWXMxVER5TlcrNnFOWEJqeUpLS2ZFWFZyUlMKQUhxWGRwS1pWZFRQR2g2V1ZocTlpNUpiSUhSbFFuRkFtMkVucDlOYmZza3EvSEFzTmRRazAwaWpQd2JiZVdndApIZ3RyTnpmZTJ5MWc2dlQyZzF2OUc2aDlFTXVDcDUrc2ZQaFVPMTJXeUFlaCtTOEtCNHlDdVZWQXhvVVFsSGRDCjh1QWFkU0d6dlIwblY0TGVlay9Mb3VoNU0zMFRzZ1BDVldGa2NrZVE4a1FIKzFsREQxMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBcFdUOHFmNmR6Mjg1R25WbkY2aE5nYzJmbjRYVkRvaE5US2JOSWhsZ3htWkZGZ0l6CnQrWFlKaENFdkE0SitPbUc1eEdLV0NzQlhLeTB4RnFHdGxTNStsc2ZBWjd6bDFDTlg2d09vemxxSm5RYXZzS1QKcXN1VDYxTDlBdzAyUzRUUkljYmRCS05veVFVOW5FSmQvWXhUMGZxRW5RaXl5Y0FkM2NGbWZwNFliY2owWTRiMgpWYU0rYlJsMGhybk1ycmc4VWIzeFd6T3diWE5CVFRyemRzWTJ0ZHd3QUxSYzRRZmNpZWQ4TmxKSzBSazk2RStnCjFCcllsT1l4NW9JS2xSM01WV29qaEJkN2NYajk4dkN1bjZYMnhxemhaM2dCUEFxcVV1RHlNcGpMb0tvbzg2OC8KNWx4SjJnblJIb0R3dThMVm5LeWwrMWtJNGhYUlhvb2t3Ukh1N1FJREFRQUJBb0lCQUg4MWF2ZThzOWZscmIvaAo2SWJUbGJsdVU0VTRSQ1JIUlZ6ZE5nMHlBN0xVMmZJUmc0Ry9zRDJtbXRDZzQ1Nmt6bk5PbEY4M3hIWnBCeWUyCmtNSVA3SExZUHNMYVpIUlBLazBaWXJDNzZoN2xVZVRDZHh6NE15N2R4MmZmYzVFbCtFdklUaG5STFRqZlpRR1kKTWY1ZlBlRFVrOGJMOStjZ2NsZ3E5aEFRdksxQ2szWUtoVUh5SmF4R0VSOTRwaVl2dThaQnpPemhKa0VVWEl5VQpqL2w1bTAxUHdqbFFPdElQQlE0MFdNQUppS3dFQlBvVWpGQkpSaHZYeFdkYm9NZ3k4WXh6MStpbU81dmhWSnN1CkxweWxQOURCcnJQTStVRFRmNTB0bEk3aXZUZzlYWHZZOXRhZmc4U21SSnE4MUg1akVyMWFacFloWElzWk9UVXIKN2tIUmVXa0NnWUVBMkhSaGRaTTlSVytteFUxTGhWM1VGajhXVDM3TGdSQUZsUGppZjAzbEFHM3RPZThJOTV6OAovRHk2MGg4R1pqRDZHMUt3UDgxVUtUVGlmcWJUUUdxVmxvdE9kZlcwUjZkZ1JpUm1wMjNMeE15bkgwV2sveVNrClg1ZnJNdmk1ZG9mQWtVd1dKRWJOK25JcHJ5YjVkcHFEQ01oclpNUlhUYnYrSzRqRnhhNUNSS3NDZ1lFQXc1eUQKNFV0SXV5WWV1YmdxMWFZcUNGeTNLRGlnY1JmV0N5ZkNMam1YU3JQK2NaR2h0R0dhQjlhbVByNlBGTnNOVXV4dworanBtRXlyQ1did2wxY3doSkoyK1AwczNFUW84alI5T3lsNEhNTkdUNm1PVjc1Q3FtVmlaUG1md3VMZWhoQnIrCjBtTy9JcWs2bER2aHpUanR1THhCemJZRVJGcXdiNGZwLzJ2ZnFzY0NnWUFxbHVPaVBjRmRpelYyTnRvNE9Ka0YKYzQ1UlAvS014M2xCc2FMblI0MWFnMGFkRXBKaUhpcU0rdW9MYy8xUFdDMnQrSndqUWFSZ296NDVpMXVmbmhrbQowT3cwTzQ4b1ZoK1VUWTlCUEZKT3U3SGFibHFqdFRMK2VDYllGYVp3VXcrcHh4M0lMNEpSMStxcHd2SnN5c1FqCmswUEdSUGVrbk92SzV4TjY3T212RndLQmdERlZ1MGxLSklqVy8yN1Z6Uy9mWGNDSUtjV2lLb3o3ZHdlUE9vRlEKRXlGTExrUlVkNVUzL0pJM2greFJRV01BTUdjV3JSUGZRTGxhMG5PeGFWVjN5M0Fodk1iWDRJYVNyMXprWlluUwpsenV2ei8rUXFGTW9pRzV1a3cvVFJUcEJUaUkwY01wOVQ4cWRKZUlYREVjbk1ZV2pMWEdGazZQdHY0d1JtbW5LCk9qb25Bb0dCQUt5OWlWLzNMRHFxcmFXZFlNV2txV1RuNmw5RUhrWVg4VEhTanprVmo3aWZWQjNVb0x6eVV0ajEKYVZQeWtNU0tZcndYNXRFM3FqWUtuNGZyS3NWY2dWbDJ4VUQ1UTAvVjcrTGplMDQwcDY4a25zR3h6VnMweXQ0ZApEVDFYaVlKaEZwYjR6VGNEQml1OVgxK1QreWk2U0tScUJPZ1BsTzFWc3hna1h6eCtWck42Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+- name: aks
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      args:
+      - get-token
+      - --login
+      - azurecli
+      - --server-id
+      - abc123
+      command: kubelogin
+      env: null
+      provideClusterInfo: false
+- name: eks
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
@@ -62,25 +76,13 @@ users:
       - eks-cluster-name
       command: aws-iam-authenticator
       env:
-        - name: foo1
-          value: bar1
-        - name: foo2
-          value: bar2
-- name: aws-noargs
+        - name: foo
+          value: bar
+- name: gke
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
-      command: aws-iam-authenticator
-      env:
-        - name: foo1
-          value: bar1
-        - name: foo2
-          value: bar2
-- name: minikube
-  user:
-    client-certificate: client.crt
-    client-key: client.key
-- name: kind-admin
-  user:
-    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM4akNDQWRxZ0F3SUJBZ0lJYW05RGQ3eU5kZHd3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2JXbHVhV3QxWW1WRFFUQWVGdzB4T1RBMU1ESXdNek0zTWpKYUZ3MHlNREExTURJd016TTNORFZhTURReApGekFWQmdOVkJBb1REbk41YzNSbGJUcHRZWE4wWlhKek1Sa3dGd1lEVlFRREV4QnJkV0psY201bGRHVnpMV0ZrCmJXbHVNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXBXVDhxZjZkejI4NUduVm4KRjZoTmdjMmZuNFhWRG9oTlRLYk5JaGxneG1aRkZnSXp0K1hZSmhDRXZBNEorT21HNXhHS1dDc0JYS3kweEZxRwp0bFM1K2xzZkFaN3psMUNOWDZ3T296bHFKblFhdnNLVHFzdVQ2MUw5QXcwMlM0VFJJY2JkQktOb3lRVTluRUpkCi9ZeFQwZnFFblFpeXljQWQzY0ZtZnA0WWJjajBZNGIyVmFNK2JSbDBocm5NcnJnOFViM3hXek93YlhOQlRUcnoKZHNZMnRkd3dBTFJjNFFmY2llZDhObEpLMFJrOTZFK2cxQnJZbE9ZeDVvSUtsUjNNVldvamhCZDdjWGo5OHZDdQpuNlgyeHF6aFozZ0JQQXFxVXVEeU1wakxvS29vODY4LzVseEoyZ25SSG9Ed3U4TFZuS3lsKzFrSTRoWFJYb29rCndSSHU3UUlEQVFBQm95Y3dKVEFPQmdOVkhROEJBZjhFQkFNQ0JhQXdFd1lEVlIwbEJBd3dDZ1lJS3dZQkJRVUgKQXdJd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFMcVJkUW9IYWJrZktzQVdLWEVqdTNRT2hxeWJPN1UwcGVkMQpDaTFoNE1xNE1POWRDM3J5b3BwTmp3ZjFlOUQyNElUREcyLzdVYkRFdkovNlhoYVFGRDM5eTI4Ump5MVlZNlUyClRSSUZXVEVRdjB3blN1elUyVGJpSXpZUU1BVlIwNjh6RUd4Q2NDWXMxVER5TlcrNnFOWEJqeUpLS2ZFWFZyUlMKQUhxWGRwS1pWZFRQR2g2V1ZocTlpNUpiSUhSbFFuRkFtMkVucDlOYmZza3EvSEFzTmRRazAwaWpQd2JiZVdndApIZ3RyTnpmZTJ5MWc2dlQyZzF2OUc2aDlFTXVDcDUrc2ZQaFVPMTJXeUFlaCtTOEtCNHlDdVZWQXhvVVFsSGRDCjh1QWFkU0d6dlIwblY0TGVlay9Mb3VoNU0zMFRzZ1BDVldGa2NrZVE4a1FIKzFsREQxMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBcFdUOHFmNmR6Mjg1R25WbkY2aE5nYzJmbjRYVkRvaE5US2JOSWhsZ3htWkZGZ0l6CnQrWFlKaENFdkE0SitPbUc1eEdLV0NzQlhLeTB4RnFHdGxTNStsc2ZBWjd6bDFDTlg2d09vemxxSm5RYXZzS1QKcXN1VDYxTDlBdzAyUzRUUkljYmRCS05veVFVOW5FSmQvWXhUMGZxRW5RaXl5Y0FkM2NGbWZwNFliY2owWTRiMgpWYU0rYlJsMGhybk1ycmc4VWIzeFd6T3diWE5CVFRyemRzWTJ0ZHd3QUxSYzRRZmNpZWQ4TmxKSzBSazk2RStnCjFCcllsT1l4NW9JS2xSM01WV29qaEJkN2NYajk4dkN1bjZYMnhxemhaM2dCUEFxcVV1RHlNcGpMb0tvbzg2OC8KNWx4SjJnblJIb0R3dThMVm5LeWwrMWtJNGhYUlhvb2t3Ukh1N1FJREFRQUJBb0lCQUg4MWF2ZThzOWZscmIvaAo2SWJUbGJsdVU0VTRSQ1JIUlZ6ZE5nMHlBN0xVMmZJUmc0Ry9zRDJtbXRDZzQ1Nmt6bk5PbEY4M3hIWnBCeWUyCmtNSVA3SExZUHNMYVpIUlBLazBaWXJDNzZoN2xVZVRDZHh6NE15N2R4MmZmYzVFbCtFdklUaG5STFRqZlpRR1kKTWY1ZlBlRFVrOGJMOStjZ2NsZ3E5aEFRdksxQ2szWUtoVUh5SmF4R0VSOTRwaVl2dThaQnpPemhKa0VVWEl5VQpqL2w1bTAxUHdqbFFPdElQQlE0MFdNQUppS3dFQlBvVWpGQkpSaHZYeFdkYm9NZ3k4WXh6MStpbU81dmhWSnN1CkxweWxQOURCcnJQTStVRFRmNTB0bEk3aXZUZzlYWHZZOXRhZmc4U21SSnE4MUg1akVyMWFacFloWElzWk9UVXIKN2tIUmVXa0NnWUVBMkhSaGRaTTlSVytteFUxTGhWM1VGajhXVDM3TGdSQUZsUGppZjAzbEFHM3RPZThJOTV6OAovRHk2MGg4R1pqRDZHMUt3UDgxVUtUVGlmcWJUUUdxVmxvdE9kZlcwUjZkZ1JpUm1wMjNMeE15bkgwV2sveVNrClg1ZnJNdmk1ZG9mQWtVd1dKRWJOK25JcHJ5YjVkcHFEQ01oclpNUlhUYnYrSzRqRnhhNUNSS3NDZ1lFQXc1eUQKNFV0SXV5WWV1YmdxMWFZcUNGeTNLRGlnY1JmV0N5ZkNMam1YU3JQK2NaR2h0R0dhQjlhbVByNlBGTnNOVXV4dworanBtRXlyQ1did2wxY3doSkoyK1AwczNFUW84alI5T3lsNEhNTkdUNm1PVjc1Q3FtVmlaUG1md3VMZWhoQnIrCjBtTy9JcWs2bER2aHpUanR1THhCemJZRVJGcXdiNGZwLzJ2ZnFzY0NnWUFxbHVPaVBjRmRpelYyTnRvNE9Ka0YKYzQ1UlAvS014M2xCc2FMblI0MWFnMGFkRXBKaUhpcU0rdW9MYy8xUFdDMnQrSndqUWFSZ296NDVpMXVmbmhrbQowT3cwTzQ4b1ZoK1VUWTlCUEZKT3U3SGFibHFqdFRMK2VDYllGYVp3VXcrcHh4M0lMNEpSMStxcHd2SnN5c1FqCmswUEdSUGVrbk92SzV4TjY3T212RndLQmdERlZ1MGxLSklqVy8yN1Z6Uy9mWGNDSUtjV2lLb3o3ZHdlUE9vRlEKRXlGTExrUlVkNVUzL0pJM2greFJRV01BTUdjV3JSUGZRTGxhMG5PeGFWVjN5M0Fodk1iWDRJYVNyMXprWlluUwpsenV2ei8rUXFGTW9pRzV1a3cvVFJUcEJUaUkwY01wOVQ4cWRKZUlYREVjbk1ZV2pMWEdGazZQdHY0d1JtbW5LCk9qb25Bb0dCQUt5OWlWLzNMRHFxcmFXZFlNV2txV1RuNmw5RUhrWVg4VEhTanprVmo3aWZWQjNVb0x6eVV0ajEKYVZQeWtNU0tZcndYNXRFM3FqWUtuNGZyS3NWY2dWbDJ4VUQ1UTAvVjcrTGplMDQwcDY4a25zR3h6VnMweXQ0ZApEVDFYaVlKaEZwYjR6VGNEQml1OVgxK1QreWk2U0tScUJPZ1BsTzFWc3hna1h6eCtWck42Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+      command: gke-gcloud-auth-plugin
+      installHint: Install gke-gcloud-auth-plugin for use with kubectl by following
+        https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+      provideClusterInfo: true

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -871,7 +871,7 @@ class TestK8sKubeconfig:
         # Incluster & Minikube & KIND fail but EKS succeeds.
         m_kind.return_value = (K8sConfig(), True)
         assert fun(kubeconf, context) == m_eks.return_value
-        m_eks.assert_called_once_with(kubeconf, context, False)
+        m_eks.assert_called_once_with(kubeconf, context)
 
         # All fail.
         m_eks.return_value = (K8sConfig(), True)

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -853,28 +853,28 @@ class TestK8sKubeconfig:
         m_kind.return_value = (K8sConfig(), False)
         m_auth.return_value = (K8sConfig(), False)
 
-        # Incluster returns a non-zero value.
+        # Authenticator succeeds.
         kubeconf, context = Filepath("kubeconf"), "context"
-        assert fun(kubeconf, context) == m_incluster.return_value
-        m_incluster.assert_called_once_with()
-
-        # Incluster fails but Minikube does not.
-        m_incluster.return_value = (K8sConfig(), True)
-        assert fun(kubeconf, context) == m_mini.return_value
-        m_mini.assert_called_once_with(kubeconf, context)
-
-        # Incluster & Minikube fail but KIND succeeds.
-        m_mini.return_value = (K8sConfig(), True)
-        assert fun(kubeconf, context) == m_kind.return_value
-        m_kind.assert_called_once_with(kubeconf, context)
-
-        # Incluster & Minikube & KIND fail but authenticator succeeds.
-        m_kind.return_value = (K8sConfig(), True)
         assert fun(kubeconf, context) == m_auth.return_value
         m_auth.assert_called_once_with(kubeconf, context)
 
-        # All fail.
+        # Authenticator fails but Incluster succeeds.
         m_auth.return_value = (K8sConfig(), True)
+        assert fun(kubeconf, context) == m_incluster.return_value
+        m_incluster.assert_called_once_with()
+
+        # Authenticator & Incluster fail but KinD succeeds.
+        m_incluster.return_value = (K8sConfig(), True)
+        assert fun(kubeconf, context) == m_kind.return_value
+        m_kind.assert_called_once_with(kubeconf, context)
+
+        # Authenticator & Incluster & KinD fail but Minikube succeeds.
+        m_kind.return_value = (K8sConfig(), True)
+        assert fun(kubeconf, context) == m_mini.return_value
+        m_mini.assert_called_once_with(kubeconf, context)
+
+        # All fail.
+        m_mini.return_value = (K8sConfig(), True)
         assert fun(kubeconf, context) == (K8sConfig(), True)
 
     def test_load_minikube_config_ok(self):


### PR DESCRIPTION
This PR modernises the Kubeconfig specimen used in the tests. The new Kubeconfig file uses contemporary examples for AKS, EKS, GKE, KinD and Minikube.

Furthermore, Square will now first try to authenticate with an authenticator app, since this is the most likely scenario.