### PR TITLE
Remove Filepath type

### DIFF
--- a/examples/as_library.py
+++ b/examples/as_library.py
@@ -10,7 +10,7 @@ Start the KinD cluster, then run this script from the parent directory like so:
 
 """
 import os
-import pathlib
+from pathlib import Path
 
 import square
 from square.dtypes import Config, GroupBy, Selectors
@@ -21,7 +21,7 @@ def main():
     #                                 Setup
     # ----------------------------------------------------------------------
     # Kubernetes credentials.
-    kubeconfig, kubecontext = pathlib.Path(os.environ["KUBECONFIG"]), None
+    kubeconfig, kubecontext = Path(os.environ["KUBECONFIG"]), None
 
     # Optional: Set log level (0 = ERROR, 1 = WARNING, 2 = INFO, 3 = DEBUG).
     square.square.setup_logging(3)
@@ -33,7 +33,7 @@ def main():
         kubecontext=kubecontext,
 
         # Store manifests in this folder.
-        folder=pathlib.PosixPath('manifests'),
+        folder=Path('manifests'),
 
         # Group the downloaded manifests by namespace, label and kind.
         groupby=GroupBy(label="app", order=["ns", "label", "kind"]),

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -1,5 +1,5 @@
-import pathlib
 import sys
+from pathlib import Path
 
 from . import square
 from .cfgfile import load
@@ -13,9 +13,9 @@ __version__ = '1.4.0'
 # Determine the base folder. This is usually the folder of this very file, but
 # will be different if we run inside a bundle produced by PyInstaller.
 if getattr(sys, '_MEIPASS', None):
-    BASE_DIR = pathlib.Path(getattr(sys, '_MEIPASS'))
+    BASE_DIR = Path(getattr(sys, '_MEIPASS'))
 else:
-    BASE_DIR = pathlib.Path(__file__).parent.parent
+    BASE_DIR = Path(__file__).parent.parent
 
 # Square will source all its default values from this configuration file. The
 # only exceptions are the namespaces. By default, Square will target all the

--- a/square/cfgfile.py
+++ b/square/cfgfile.py
@@ -99,12 +99,11 @@ def merge(src: list, dst: list) -> list:
 
 def load(fname: Path) -> Tuple[Config, bool]:
     """Parse the Square configuration file `fname` and return it as a `Config`."""
-    err_resp = Config(folder=Path(""), kubeconfig=Path("")), True
-    fname = Path(fname)
+    err_resp = Config(folder=Path(), kubeconfig=Path()), True
 
     # Load the configuration file.
     try:
-        raw = yaml.safe_load(Path(fname).read_text())
+        raw = yaml.safe_load(fname.read_text())
     except FileNotFoundError as e:
         logit.error(f"Cannot load config file <{fname}>: {e.args[1]}")
         return err_resp

--- a/square/cfgfile.py
+++ b/square/cfgfile.py
@@ -9,13 +9,14 @@ This module defines utility functions to define these filters.
 """
 import copy
 import logging
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Tuple
 
 import pydantic
 import yaml
 
-from square.dtypes import Config, Filepath
+from square.dtypes import Config
 
 from .dtypes import FiltersKind
 
@@ -96,14 +97,14 @@ def merge(src: list, dst: list) -> list:
     return dst
 
 
-def load(fname: Filepath) -> Tuple[Config, bool]:
+def load(fname: Path) -> Tuple[Config, bool]:
     """Parse the Square configuration file `fname` and return it as a `Config`."""
-    err_resp = Config(folder=Filepath(""), kubeconfig=Filepath("")), True
-    fname = Filepath(fname)
+    err_resp = Config(folder=Path(""), kubeconfig=Path("")), True
+    fname = Path(fname)
 
     # Load the configuration file.
     try:
-        raw = yaml.safe_load(Filepath(fname).read_text())
+        raw = yaml.safe_load(Path(fname).read_text())
     except FileNotFoundError as e:
         logit.error(f"Cannot load config file <{fname}>: {e.args[1]}")
         return err_resp

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,10 +1,7 @@
-import pathlib
+from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple
 
 from pydantic import BaseModel, Field
-
-# All files in Square have this type.
-Filepath = pathlib.Path
 
 # Square will first save/deploy the resources in this list in this order.
 # Afterwards it will move on to all those resources not in this list. The order
@@ -40,8 +37,8 @@ DEFAULT_PRIORITIES = (
 #                                  Kubernetes
 # -----------------------------------------------------------------------------
 class K8sClientCert(NamedTuple):
-    crt: Filepath = Filepath()
-    key: Filepath = Filepath()
+    crt: Path = Path()
+    key: Path = Path()
 
 
 class MetaManifest(NamedTuple):
@@ -76,7 +73,7 @@ class K8sConfig(NamedTuple):
 
     # Certificate authority credentials and self signed client certificate.
     # Used to authenticate to eg GKE.
-    ca_cert: Filepath = Filepath()
+    ca_cert: Path = Path()
     client_cert: Optional[K8sClientCert] = None
 
     # A persistent session from the "requests" library for this cluster.
@@ -221,10 +218,10 @@ Filters = Dict[str, FiltersKind]
 class Config(BaseModel):
     """Uniform interface into top level Square API."""
     # Path to local manifests eg "./foo"
-    folder: Filepath
+    folder: Path
 
     # Path to Kubernetes credentials.
-    kubeconfig: Filepath
+    kubeconfig: Path
 
     # Kubernetes context (use `None` to use the default).
     kubecontext: Optional[str] = None
@@ -251,6 +248,6 @@ class Config(BaseModel):
 # -----------------------------------------------------------------------------
 #                                 Miscellaneous
 # -----------------------------------------------------------------------------
-LocalManifests = Dict[Filepath, Tuple[MetaManifest, dict]]
-LocalManifestLists = Dict[Filepath, List[Tuple[MetaManifest, dict]]]
+LocalManifests = Dict[Path, Tuple[MetaManifest, dict]]
+LocalManifestLists = Dict[Path, List[Tuple[MetaManifest, dict]]]
 SquareManifests = Dict[MetaManifest, dict]

--- a/square/main.py
+++ b/square/main.py
@@ -181,7 +181,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
     # Load the default configuration unless the user specified an explicit one.
     if p.configfile:
         logit.info(f"Loading configuration file <{p.configfile}>")
-        cfg, err = square.cfgfile.load(p.configfile)
+        cfg, err = square.cfgfile.load(Path(p.configfile))
 
         # Look for `--kubeconfig`. Defaults to the value in config file.
         kubeconfig = p.kubeconfig or cfg.kubeconfig

--- a/square/main.py
+++ b/square/main.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import colorama
@@ -9,7 +10,7 @@ import square
 import square.k8s
 import square.square
 from square import DEFAULT_CONFIG_FILE, __version__
-from square.dtypes import Config, Filepath, GroupBy, Selectors
+from square.dtypes import Config, GroupBy, Selectors
 
 # Convenience: global logger instance to avoid repetitive code.
 logit = logging.getLogger("square")
@@ -166,8 +167,8 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
 
     """
     err_resp = Config(
-        folder=Filepath(""),
-        kubeconfig=Filepath(""),
+        folder=Path(""),
+        kubeconfig=Path(""),
         kubecontext=None,
         selectors=Selectors(),
         groupby=GroupBy(label="", order=[]),
@@ -188,7 +189,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         # Pick the configuration file. Depends on whether the user specified
         # `--no-config`, `--config` and if `.square.yaml` exists.
         default_cfg = DEFAULT_CONFIG_FILE
-        dot_square = Filepath(".square.yaml")
+        dot_square = Path(".square.yaml")
 
         if p.no_config:
             cfg_file = default_cfg
@@ -202,7 +203,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         # `--config`, `.square`, `KUBECONFIG` environment variable.
         if cfg_file == default_cfg:
             kubeconfig = p.kubeconfig or os.getenv("KUBECONFIG", "")
-            cfg.folder = Filepath.cwd()
+            cfg.folder = Path.cwd()
         else:
             kubeconfig = p.kubeconfig or str(cfg.kubeconfig) or os.getenv("KUBECONFIG", "")  # noqa
 
@@ -219,8 +220,8 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
     folder = cfg.folder if p.folder is None else p.folder
 
     # Expand the user's home folder, ie if the path contains a "~".
-    folder = Filepath(folder).expanduser()
-    kubeconfig = Filepath(kubeconfig).expanduser()
+    folder = Path(folder).expanduser()
+    kubeconfig = Path(kubeconfig).expanduser()
 
     # ------------------------------------------------------------------------
     # GroupBy (determines the folder hierarchy that GET will create).
@@ -267,7 +268,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
 
     # Use the value from the (default) config file unless the user overrode
     # them on the command line.
-    kubeconfig = Filepath(kubeconfig)
+    kubeconfig = Path(kubeconfig)
     kubecontext = p.kubecontext or cfg.kubecontext
     namespaces = cfg.selectors.namespaces if p.namespaces is None else p.namespaces
     sel_labels = cfg.selectors.labels if p.labels is None else p.labels
@@ -388,7 +389,7 @@ def main() -> int:
 
     # Create a default ".square.yaml" in the current folder and quit.
     if param.parser == "config":
-        fname = Filepath(param.folder or ".") / ".square.yaml"
+        fname = Path(param.folder or ".") / ".square.yaml"
         fname.parent.mkdir(parents=True, exist_ok=True)
         fname.write_text(DEFAULT_CONFIG_FILE.read_text())
         print(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
-import pathlib
 import unittest.mock as mock
+from pathlib import Path
 from typing import Generator
 
 import pytest
 
 import square.cfgfile
 import square.square
-from square.dtypes import Filepath, K8sConfig
+from square.dtypes import K8sConfig
 
 from .test_helpers import k8s_apis
 
@@ -16,7 +16,7 @@ def pytest_configure(*args, **kwargs):
     # Set log level to DEBUG for all unit tests.
     square.square.setup_logging(9)
 
-    if pathlib.Path(".square.yaml").exists():
+    if Path(".square.yaml").exists():
         print("\n--- Found `.square.yaml` in root folder. "
               "The tests cannot tolerate that. ABORT ---\n")
         assert False
@@ -64,7 +64,7 @@ def config(k8sconfig, tmp_path) -> Generator[square.dtypes.Config, None, None]:
 
     """
     # Load the sample configuration.
-    cfg, err = square.cfgfile.load(Filepath("tests/support/config.yaml"))
+    cfg, err = square.cfgfile.load(Path("tests/support/config.yaml"))
     assert not err
 
     # Point the folder and kubeconfig to temporary versions.

--- a/tests/test_cfgfile.py
+++ b/tests/test_cfgfile.py
@@ -1,23 +1,24 @@
 import copy
 import sys
+from pathlib import Path
 
 import yaml
 
 import square
 import square.cfgfile as cfgfile
-from square.dtypes import DEFAULT_PRIORITIES, Config, Filepath
+from square.dtypes import DEFAULT_PRIORITIES, Config
 
 
 class TestLoadConfig:
     def test_load(self):
         """Load and parse configuration file."""
         # Load the sample that ships with Square.
-        fname = Filepath("tests/support/config.yaml")
+        fname = Path("tests/support/config.yaml")
         cfg, err = cfgfile.load(fname)
         assert not err and isinstance(cfg, Config)
 
         assert cfg.folder == fname.parent.absolute() / "some/path"
-        assert cfg.kubeconfig == Filepath("/path/to/kubeconfig")
+        assert cfg.kubeconfig == Path("/path/to/kubeconfig")
         assert cfg.kubecontext is None
         assert cfg.priorities == list(DEFAULT_PRIORITIES)
         assert cfg.selectors.kinds == set(DEFAULT_PRIORITIES)
@@ -30,7 +31,7 @@ class TestLoadConfig:
     def test_load_folder_paths(self, tmp_path):
         """The folder paths must always be relative to the config file."""
         fname = tmp_path / ".square.yaml"
-        fname_ref = Filepath("tests/support/config.yaml")
+        fname_ref = Path("tests/support/config.yaml")
 
         # The parsed folder must point to "tmp_path".
         ref = yaml.safe_load(fname_ref.read_text())
@@ -52,11 +53,11 @@ class TestLoadConfig:
             ref["folder"] = "/absolute/path"
             fname.write_text(yaml.dump(ref))
             cfg, err = cfgfile.load(fname)
-            assert not err and cfg.folder == Filepath("/absolute/path")
+            assert not err and cfg.folder == Path("/absolute/path")
 
     def test_common_filters(self, tmp_path):
         """Deal with empty or non-existing `_common_` filter."""
-        fname_ref = Filepath("tests/support/config.yaml")
+        fname_ref = Path("tests/support/config.yaml")
 
         # ----------------------------------------------------------------------
         # Empty _common_ filters.
@@ -118,7 +119,7 @@ class TestLoadConfig:
 
         # Load the sample configuration and corrupt the label selector. Instead
         # of a list of 2-tuples we make it a list of 3-tuples.
-        cfg = yaml.safe_load(Filepath("tests/support/config.yaml").read_text())
+        cfg = yaml.safe_load(Path("tests/support/config.yaml").read_text())
         cfg["selectors"]["labels"] = [["foo", "bar", "foobar"]]
         fout = tmp_path / "corrupt.yaml"
         fout.write_text(yaml.dump(cfg))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,7 @@
 import copy
-import pathlib
 import time
 import unittest.mock as mock
+from pathlib import Path
 
 import httpx
 import pytest
@@ -11,7 +11,7 @@ import yaml
 import square.k8s
 import square.main
 import square.manio as manio
-from square.dtypes import Config, Filepath, GroupBy, K8sConfig, Selectors
+from square.dtypes import Config, GroupBy, K8sConfig, Selectors
 
 from .test_helpers import kind_available
 
@@ -34,7 +34,7 @@ class TestBasic:
 
         # Fixtures.
         fun = square.k8s.cluster_config
-        fname = Filepath("/tmp/kubeconfig-kind.yaml")
+        fname = Path("/tmp/kubeconfig-kind.yaml")
 
         # Must produce a valid K8s configuration.
         cfg, err = fun(fname, None)
@@ -50,7 +50,7 @@ class TestBasic:
 @pytest.mark.skipif(not kind_available(), reason="No Integration Test Cluster")
 class TestMainGet:
     def setup_method(self):
-        cur_path = pathlib.Path(__file__).parent.parent
+        cur_path = Path(__file__).parent.parent
         integration_test_manifest_path = cur_path / "integration-test-cluster"
         assert integration_test_manifest_path.exists()
         assert integration_test_manifest_path.is_dir()
@@ -292,7 +292,7 @@ class TestMainGet:
             folder=tmp_path,
             groupby=GroupBy(label="app", order=[]),
             kubecontext=None,
-            kubeconfig=Filepath("/tmp/kubeconfig-kind.yaml"),
+            kubeconfig=Path("/tmp/kubeconfig-kind.yaml"),
             selectors=Selectors(
                 kinds={"HorizontalPodAutoscaler"},
                 namespaces=["test-hpa"],
@@ -337,7 +337,7 @@ class TestKindName:
         # Populate the `Config` structure. All main functions expect this.
         config = Config(
             kubecontext=None,
-            kubeconfig=Filepath("/tmp/kubeconfig-kind.yaml"),
+            kubeconfig=Path("/tmp/kubeconfig-kind.yaml"),
 
             # Store manifests in this folder.
             folder=tmp_path / 'manifests',
@@ -479,7 +479,7 @@ class TestMainPlan:
             folder=tmp_path / "backup",
             groupby=GroupBy(label="app", order=[]),
             kubecontext=None,
-            kubeconfig=Filepath("/tmp/kubeconfig-kind.yaml"),
+            kubeconfig=Path("/tmp/kubeconfig-kind.yaml"),
             priorities=priorities,
             selectors=Selectors(
                 kinds=set(priorities),
@@ -560,7 +560,7 @@ class TestMainPlan:
             folder=tmp_path,
             groupby=GroupBy(label="app", order=[]),
             kubecontext=None,
-            kubeconfig=Filepath("/tmp/kubeconfig-kind.yaml"),
+            kubeconfig=Path("/tmp/kubeconfig-kind.yaml"),
             selectors=Selectors(
                 kinds={"HorizontalPodAutoscaler"},
                 namespaces=["test-hpa"],

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1,6 +1,5 @@
 import json
 import os
-import pathlib
 import random
 import sys
 import time
@@ -14,7 +13,7 @@ import yaml
 
 import square.k8s as k8s
 import square.square
-from square.dtypes import Filepath, K8sConfig, K8sResource, MetaManifest
+from square.dtypes import K8sConfig, K8sResource, MetaManifest
 
 from .test_helpers import kind_available
 
@@ -309,7 +308,7 @@ class TestUrlPathBuilder:
 
         if not kind_available():
             pytest.skip()
-        kubeconfig = Filepath("/tmp/kubeconfig-kind.yaml")
+        kubeconfig = Path("/tmp/kubeconfig-kind.yaml")
 
         # Create a genuine K8s config from our integration test cluster.
         k8sconfig, err = k8s.cluster_config(kubeconfig, None)
@@ -831,7 +830,7 @@ class TestK8sKubeconfig:
     @mock.patch.object(k8s, "version")
     @mock.patch.object(k8s, "compile_api_endpoints")
     def test_cluster_config(self, m_compile_endpoints, m_version, m_load_auto, k8sconfig):
-        kubeconfig = Filepath("kubeconfig")
+        kubeconfig = Path("kubeconfig")
         kubecontext = None
 
         m_load_auto.return_value = (k8sconfig, False)
@@ -854,7 +853,7 @@ class TestK8sKubeconfig:
         m_auth.return_value = (K8sConfig(), False)
 
         # Authenticator succeeds.
-        kubeconf, context = Filepath("kubeconf"), "context"
+        kubeconf, context = Path("kubeconf"), "context"
         assert fun(kubeconf, context) == m_auth.return_value
         m_auth.assert_called_once_with(kubeconf, context)
 
@@ -879,16 +878,16 @@ class TestK8sKubeconfig:
 
     def test_load_minikube_config_ok(self):
         # Load the K8s configuration for "minikube" context.
-        fname = Filepath("tests/support/kubeconf.yaml")
+        fname = Path("tests/support/kubeconf.yaml")
 
         # Verify the expected output.
         ref = K8sConfig(
             url="https://192.168.0.177:8443",
             token="",
-            ca_cert=Filepath("ca.crt"),
+            ca_cert=Path("ca.crt"),
             client_cert=k8s.K8sClientCert(
-                crt=Filepath("client.crt"),
-                key=Filepath("client.key"),
+                crt=Path("client.crt"),
+                key=Path("client.key"),
             ),
             version="",
             name="minikube",
@@ -896,8 +895,8 @@ class TestK8sKubeconfig:
         expected = (ref, False)
         assert k8s.load_minikube_config(fname, "minikube") == expected
 
-        # Function must also accept pathlib.Path instances.
-        assert expected == k8s.load_minikube_config(pathlib.Path(fname), None)
+        # Function must also accept `Path` instances.
+        assert expected == k8s.load_minikube_config(Path(fname), None)
 
         # Minikube also happens to be the default context, so not supplying an
         # explicit context must return the same information.
@@ -905,7 +904,7 @@ class TestK8sKubeconfig:
 
     def test_load_kind_config_ok(self):
         # Load the K8s configuration for a Kind cluster.
-        fname = Filepath("tests/support/kubeconf.yaml")
+        fname = Path("tests/support/kubeconf.yaml")
 
         ret, err = k8s.load_kind_config(fname, "kind")
         assert not err
@@ -914,8 +913,8 @@ class TestK8sKubeconfig:
         assert ret.version == ""
         assert ret.name == "kind"
 
-        # Function must also accept pathlib.Path instances.
-        ret, err = k8s.load_kind_config(pathlib.Path(fname), "kind")
+        # Function must also accept `Path` instances.
+        ret, err = k8s.load_kind_config(Path(fname), "kind")
         assert not err
         assert ret.url == "https://localhost:8443"
         assert ret.token == ""
@@ -934,11 +933,11 @@ class TestK8sKubeconfig:
         fun = k8s.load_kind_config if kubetype == "kind" else k8s.load_minikube_config
 
         # Valid Kubeconfig file but it has no "invalid" context.
-        fname = Filepath("tests/support/kubeconf.yaml")
+        fname = Path("tests/support/kubeconf.yaml")
         assert fun(fname, "invalid") == (K8sConfig(), True)
 
         # Valid Kubeconfig file but not for KinD.
-        fname = Filepath("tests/support/kubeconf.yaml")
+        fname = Path("tests/support/kubeconf.yaml")
         assert fun(fname, "gke") == (K8sConfig(), True)
 
         # Create a corrupt Kubeconfig file.
@@ -967,7 +966,7 @@ class TestK8sKubeconfig:
         m_run.return_value = types.SimpleNamespace(stdout=token.encode("utf8"))
 
         # Load the K8s configuration for the current `context`.
-        fname = Filepath("tests/support/kubeconf.yaml")
+        fname = Path("tests/support/kubeconf.yaml")
         ret, err = k8s.load_authenticator_config(fname, context)
         assert not err and isinstance(ret, K8sConfig)
 
@@ -1008,7 +1007,7 @@ class TestK8sKubeconfig:
     def test_load_authenticator_config_err(self, m_run):
         """Load K8s configuration from demo kubeconfig."""
         # Valid kubeconfig file.
-        fname = Filepath("tests/support/kubeconf.yaml")
+        fname = Path("tests/support/kubeconf.yaml")
         err_resp = (K8sConfig(), True)
 
         # Pretend the `aws-iam-authenticator` binary does not exist.
@@ -1043,7 +1042,7 @@ class TestK8sKubeconfig:
     def test_load_all_supported_kubeconfig_styles(self, m_run):
         """Verify that we can load every config style from our Kubeconfig specimen."""
         # Kubeconfig specimen.
-        fname = Filepath("tests/support/kubeconf.yaml")
+        fname = Path("tests/support/kubeconf.yaml")
 
         # Mock the call to the external authenticator and make it return a token.
         token = yaml.dump({"status": {"token": "token"}})
@@ -1062,7 +1061,7 @@ class TestK8sKubeconfig:
 
         """
         # Convenience.
-        P = Filepath("tests/support")
+        P = Path("tests/support")
 
         # Expected failure response.
         resp = (K8sConfig(), True)

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,6 +1,7 @@
 import copy
 import random
 import unittest.mock as mock
+from pathlib import Path
 from typing import cast
 
 import square.cfgfile
@@ -10,8 +11,8 @@ import square.manio as manio
 import square.square as sq
 from square.dtypes import (
     DEFAULT_PRIORITIES, Config, DeltaCreate, DeltaDelete, DeltaPatch,
-    DeploymentPlan, DeploymentPlanMeta, Filepath, GroupBy, JsonPatch,
-    K8sConfig, KindName, MetaManifest, Selectors, SquareManifests,
+    DeploymentPlan, DeploymentPlanMeta, GroupBy, JsonPatch, K8sConfig,
+    KindName, MetaManifest, Selectors, SquareManifests,
 )
 from square.k8s import resource
 
@@ -103,8 +104,8 @@ class TestBasic:
     def test_translate_resource_kinds_simple(self, k8sconfig):
         """Translate various spellings in `selectors.kinds`"""
         cfg = Config(
-            folder=Filepath('/tmp'),
-            kubeconfig=Filepath(),
+            folder=Path('/tmp'),
+            kubeconfig=Path(),
             kubecontext=None,
             groupby=GroupBy(),
             priorities=["ns", "DEPLOYMENT"],
@@ -143,8 +144,8 @@ class TestBasic:
                  "ns", "namespace/foo",
                  "unknown-a", "unknown-b/foo"}
         cfg = Config(
-            folder=Filepath('/tmp'),
-            kubeconfig=Filepath(),
+            folder=Path('/tmp'),
+            kubeconfig=Path(),
             kubecontext=None,
             groupby=GroupBy(),
             priorities=[],


### PR DESCRIPTION
`Filepath` has been an alias for `pathlib.Path`. There is no need for it.