### PR TITLE
Bump version: 1.4.0 → 1.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.5.0
 commit = True
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![](https://img.shields.io/badge/license-Apache%202-blue.svg)]()
 [![](https://img.shields.io/badge/python-3.10,3.11-blue.svg)]()
-[![](https://img.shields.io/badge/latest-v1.4.0-blue.svg)]()
+[![](https://img.shields.io/badge/latest-v1.5.0-blue.svg)]()
 [![](https://github.com/olitheolix/square/workflows/build/badge.svg)]()
 [![](https://img.shields.io/codecov/c/github/olitheolix/square.svg?style=flat)]()
 
@@ -30,7 +30,7 @@ use `pip` to install it into a Python 3.10+ environment:
 ```console
 foo@bar:~$ pip install kubernetes-square --upgrade
 foo@bar:~$ square version
-1.4.0
+1.5.0
 ```
 
 # Quickstart

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kubernetes-square"
-version = "1.4.0"
+version = "1.5.0"
 description = ""
 authors = ["Oliver Nagy <olitheolix@gmail.com>"]
 packages = [

--- a/square/__init__.py
+++ b/square/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from . import square
 from .cfgfile import load
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Switch from `Requests` to `HTTPX` to gain support for HTTP/2.