### PR TITLE
Rework manifest selection

### DIFF
--- a/square/manio.py
+++ b/square/manio.py
@@ -48,7 +48,7 @@ def make_meta(manifest: dict) -> MetaManifest:
 
 
 def select(manifest: dict, selectors: Selectors,
-           match_labels: bool = True) -> bool:
+           match_labels: bool) -> bool:
     """Return `False` unless `manifest` satisfies _all_ `selectors`.
 
     Inputs:
@@ -231,7 +231,7 @@ def parse(file_yaml: Dict[Path, str],
             manifests = [_ for _ in manifests if _ is not None]
 
             # Retain only those manifests that satisfy the selectors.
-            manifests = [_ for _ in manifests if select(_, selectors)]
+            manifests = [_ for _ in manifests if select(_, selectors, True)]
 
             # Convert List[manifest] into List[(MetaManifest, manifest)].
             # Abort if `make_meta` throws a KeyError which happens if `file_yaml`
@@ -320,7 +320,7 @@ def sync(local_manifests: LocalManifestLists,
     # Only retain server manifests that match the selectors.
     server_manifests = {
         meta: manifest for meta, manifest in server_manifests.items()
-        if select(manifest, selectors)
+        if select(manifest, selectors, True)
     }
 
     # Add all local manifests that do not match the selectors to the server
@@ -330,7 +330,7 @@ def sync(local_manifests: LocalManifestLists,
     # the diffs.
     for fname, manifests in local_manifests.items():
         for meta, manifest in manifests:
-            if select(manifest, selectors):
+            if select(manifest, selectors, True):
                 continue
             server_manifests[meta] = manifest
 

--- a/square/manio.py
+++ b/square/manio.py
@@ -47,12 +47,16 @@ def make_meta(manifest: dict) -> MetaManifest:
     )
 
 
-def select(manifest: dict, selectors: Selectors) -> bool:
+def select(manifest: dict, selectors: Selectors,
+           match_labels: bool = True) -> bool:
     """Return `False` unless `manifest` satisfies _all_ `selectors`.
 
     Inputs:
         manifests: dict
-        selectors: Selectors,
+        selectors: Selectors
+        match_labels: bool
+            Skip label matching if `False`. This flag does not affect KIND or
+            Namespace matching.
 
     Returns:
         bool: `True` iff the resource matches all selectors.
@@ -111,7 +115,7 @@ def select(manifest: dict, selectors: Selectors) -> bool:
         return False
 
     # The manifest must match all label selectors to be included.
-    if label_selectors:
+    if label_selectors and match_labels:
         # Convert the labels dictionary into a Set of (key, value) tuples. We can
         # then use set-logic to determine if the manifest has the necessary labels.
         labels = set(labels.items())

--- a/square/square.py
+++ b/square/square.py
@@ -737,11 +737,11 @@ def pick_manifests_for_plan(
 
     sel_local = {
         meta: man for meta, man in local.items()
-        if manio.select(man, selectors)
+        if manio.select(man, selectors, True)
     }
     sel_server = {
         meta: man for meta, man in server.items()
-        if manio.select(man, selectors)
+        if manio.select(man, selectors, True)
     }
     return sel_local, sel_server
 

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -81,7 +81,7 @@ class TestHelpers:
         kinds = ({"Namespace"}, {"Deployment", "Namespace"})
         for kind, ns, lab in itertools.product(kinds, namespaces, labels):
             sel = Sel(kinds=kind, namespaces=ns, labels=cast(List[str], lab))
-            assert select(manifest, sel) is True
+            assert select(manifest, sel, True) is True
 
         # Function must reject these because the selectors match only partially.
         selectors = [
@@ -91,11 +91,11 @@ class TestHelpers:
             Sel(kinds={"Namespace"}, namespaces=["ns0"], labels=["app=a", "env=x"]),
         ]
         for sel in selectors:
-            assert select(manifest, sel) is False
+            assert select(manifest, sel, True) is False
 
         # Reject the manifest if the selector does not specify at least one "kind".
-        assert select(manifest, Sel(kinds={"Namespace"})) is True
-        assert select(manifest, Sel()) is False
+        assert select(manifest, Sel(kinds={"Namespace"}), True) is True
+        assert select(manifest, Sel(), True) is False
 
         # ---------------------------------------------------------------------
         #                      Deployment Manifest
@@ -106,7 +106,7 @@ class TestHelpers:
         namespaces = (["my-ns"], ["my-ns", "other-ns"])
         for kind, ns, lab in itertools.product(kinds, namespaces, labels):
             sel = Sel(kinds=kind, namespaces=ns, labels=cast(List[str], lab))
-            assert select(manifest, sel) is True
+            assert select(manifest, sel, True) is True
 
         # Function must reject these because the selectors match only partially.
         selectors = [
@@ -116,11 +116,11 @@ class TestHelpers:
             Sel(kinds={"Deployment"}, namespaces=["ns0"], labels=["app=a", "env=x"]),
         ]
         for sel in selectors:
-            assert select(manifest, sel) is False
+            assert select(manifest, sel, True) is False
 
         # Reject the manifest if the selector does not specify at least one "kind".
-        assert select(manifest, Sel(kinds={"Deployment"})) is True
-        assert select(manifest, Sel()) is False
+        assert select(manifest, Sel(kinds={"Deployment"}), True) is True
+        assert select(manifest, Sel(), True) is False
 
         # ---------------------------------------------------------------------
         #                      ClusterRole Manifest
@@ -131,7 +131,7 @@ class TestHelpers:
         namespaces = (["my-ns"], ["my-ns", "other-ns"])
         for kind, ns, lab in itertools.product(kinds, namespaces, labels):
             sel = Sel(kinds=kind, namespaces=ns, labels=cast(List[str], lab))
-            assert select(manifest, sel) is True
+            assert select(manifest, sel, True) is True
 
         # Function must reject these because the selectors match only partially.
         selectors = [
@@ -140,10 +140,10 @@ class TestHelpers:
             Sel(kinds={"Clusterrole"}, namespaces=["ns0"], labels=["app=a", "env=x"]),
         ]
         for sel in selectors:
-            assert select(manifest, sel) is False
+            assert select(manifest, sel, True) is False
 
         # Reject the manifest if the selector does not specify at least one "kind".
-        assert select(manifest, Sel()) is False
+        assert select(manifest, Sel(), True) is False
 
         # ---------------------------------------------------------------------
         #                    Default Service Account
@@ -151,11 +151,11 @@ class TestHelpers:
         # Must always ignore "default" service account.
         kind, ns = "ServiceAccount", "ns1"
         manifest = make_manifest(kind, ns, "default")
-        assert select(manifest, Sel(kinds={kind}, namespaces=[ns])) is False
+        assert select(manifest, Sel(kinds={kind}, namespaces=[ns]), True) is False
 
         # Must select all other Secret that match the selector.
         manifest = make_manifest(kind, ns, "some-service-account")
-        assert select(manifest, Sel(kinds={kind}, namespaces=[ns])) is True
+        assert select(manifest, Sel(kinds={kind}, namespaces=[ns]), True) is True
 
         # ---------------------------------------------------------------------
         #                      Default Token Secret
@@ -163,11 +163,11 @@ class TestHelpers:
         # Must always ignore "default-token-*" Secrets.
         kind, ns = "Secret", "ns1"
         manifest = make_manifest(kind, ns, "default-token-12345")
-        assert select(manifest, Sel(kinds={kind}, namespaces=[ns])) is False
+        assert select(manifest, Sel(kinds={kind}, namespaces=[ns]), True) is False
 
         # Must select all other Secret that match the selector.
         manifest = make_manifest(kind, ns, "some-secret")
-        assert select(manifest, Sel(kinds={kind}, namespaces=[ns])) is True
+        assert select(manifest, Sel(kinds={kind}, namespaces=[ns]), True) is True
 
     def test_select_ignore_labels(self):
         """The `select` function must ignore `labels` when asked."""
@@ -198,22 +198,22 @@ class TestHelpers:
         # Must be selected because it is a Pod.
         for namespaces in ([], ["ns"]):
             selector = Selectors(kinds={"Pod"}, namespaces=namespaces)
-            assert select(manifest, selector) is True
+            assert select(manifest, selector, True) is True
 
         # Must be selected because it is uniquely specified Pod.
         for namespaces in ([], ["ns"]):
             selector = Selectors(kinds={"Pod/app"}, namespaces=namespaces)
-            assert select(manifest, selector) is True
+            assert select(manifest, selector, True) is True
 
         # Must not select it because it is not the uniquely specified Pod.
         for namespaces in ([], ["ns"]):
             selector = Selectors(kinds={"Pod/foo"}, namespaces=namespaces)
-            assert select(manifest, selector) is False
+            assert select(manifest, selector, True) is False
 
         # Must be selected because it is covered by "Pod".
         for namespaces in ([], ["ns"]):
             selector = Selectors(kinds={"Pod/foo", "Pod"}, namespaces=namespaces)
-            assert select(manifest, selector) is True
+            assert select(manifest, selector, True) is True
 
         # Must never select the manifest if the namespace is wrong.
         selectors = [
@@ -223,7 +223,7 @@ class TestHelpers:
             Selectors(kinds={"Pod/foo", "Pod"}, namespaces=["wrong"]),
         ]
         for selector in selectors:
-            assert select(manifest, selector) is False
+            assert select(manifest, selector, True) is False
 
 
 class TestUnpackParse:


### PR DESCRIPTION
This is in preparation for a bugfix. 

The main purpose of this PR is lift the manifest selection from the lower level functions like `unpack_k8s_resource_list` and `load_manifest` into the higher level functions `make_manifests` and `get_resources`.

This does not change the behavior of Square.