### PR TITLE
fix(ci): use matrix builds in GHA "release" action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,144 +6,73 @@ on:
     tags: [ "*" ]
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Build Linux Binary
-        run: |
-          python -m pip install --upgrade pip
-          pip install pipenv pyinstaller==5.9
-          pipenv install --system
-
-          pyinstaller square.spec --clean
-      - uses: actions/upload-artifact@v3
-        with:
-          name: square-linux-amd64
-          path: dist/square
-
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-      - name: Build Windows Binary
-        run: |
-          python -m pip install --upgrade pip
-          pip install pipenv pyinstaller==5.9 macholib pypiwin32 atomicwrites
-          pipenv install --system
-
-          pyinstaller square.spec --clean
-      - name: create-artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: square-windows-amd64
-          path: dist/square.exe
-
-  macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Build MacOS Binary
-        run: |
-          python -m pip install --upgrade pip
-          pip install pipenv pyinstaller==5.9
-          pipenv install --system
-
-          pyinstaller square.spec --clean
-      - uses: actions/upload-artifact@v3
-        with:
-          name: square-darwin-amd64
-          path: dist/square
-
   create-release:
-    needs: [linux, macos, windows]
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/download-artifact@master
-        with:
-          name: square-linux-amd64
-          path: linux
-      - uses: actions/download-artifact@master
-        with:
-          name: square-darwin-amd64
-          path: macos
-      - uses: actions/download-artifact@master
-        with:
-          name: square-windows-amd64
-          path: windows
-
-      # Extract branch & tag name. This is from
-      # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/td-p/31595/page/2
-      - name: Branch name
-        id: branch_name
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-
-      - name: Prepare Binaries
-        run: |
-          ls -al
-          ls -R
-          mkdir bin
-          mv linux/square bin/square-linux-amd64
-          mv macos/square bin/square-darwin-amd64
-          mv windows/square.exe bin/square-windows-amd64.exe
-          ls -R
-
-      - uses: actions/create-release@v1
+      - uses: ncipollo/release-action@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: false
+          draft: true
           prerelease: false
 
-      - name: Upload Linux
-        id: upload-linux-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/square-linux-amd64
-          asset_name: square-${{ steps.branch_name.outputs.SOURCE_TAG }}-linux-amd64
-          asset_content_type: application/binary
+  build-binaries:
+    needs: [create-release]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
 
-      - name: Upload MacOS
-        id: upload-macos-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
+      - uses: actions/setup-python@v4
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/square-darwin-amd64
-          asset_name: square-${{ steps.branch_name.outputs.SOURCE_TAG }}-darwin-amd64
-          asset_content_type: application/binary
+          python-version: '3.10'
 
-      - name: Upload Windows
-        id: upload-windows-asset
-        uses: actions/upload-release-asset@v1
+      - name: Set Linux Variables
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          echo "SQUARE_BUILD_PATH=dist/square" >> "$GITHUB_ENV"
+          echo "SQUARE_ASSET_NAME=square-${GITHUB_REF_NAME}-linux-amd64" >> "$GITHUB_ENV"
+
+      - name: Set MacOS Variables
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          echo "SQUARE_BUILD_PATH=dist/square" >> "$GITHUB_ENV"
+          echo "SQUARE_ASSET_NAME=square-${GITHUB_REF_NAME}-darwin-amd64" >> "$GITHUB_ENV"
+
+      - name: Set Windows Variables
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          echo "SQUARE_BUILD_PATH=dist/square.exe"  >> "$GITHUB_ENV"
+          echo "SQUARE_ASSET_NAME=square-${GITHUB_REF_NAME}-windows-amd64"  >> "$GITHUB_ENV"
+
+      - name: Install Pipenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv pyinstaller==5.9
+
+      - name: Install extra dependencies (Windows only)
+        if: matrix.os == 'windows-latest'
+        run: |
+          pip install macholib pypiwin32 atomicwrites
+
+      - name: Build Binary
+        run: |
+          pyinstaller square.spec --clean
+
+      - name: Upload Asset
+        uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/square-windows-amd64.exe
-          asset_name: square-${{ steps.branch_name.outputs.SOURCE_TAG }}-windows-amd64.exe
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.SQUARE_BUILD_PATH }}
+          asset_name: ${{ env.SQUARE_ASSET_NAME }}
           asset_content_type: application/binary


### PR DESCRIPTION
* Use matrix build to produce binaries for all platforms.
* Upgrade the outdated actions.