### PR TITLE
Build binaries with Python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Set Linux Variables
         if: matrix.os == 'ubuntu-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,17 @@
 name = "kubernetes-square"
 version = "1.5.1"
 description = ""
+readme = "README.md"
 authors = ["Oliver Nagy <olitheolix@gmail.com>"]
 packages = [
     { include = "square" },
 ]
 include = ["resources/defaultconfig.yaml"]
-
+classifiers = [
+    "Topic :: Kubernetes :: Build Tools",
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
 
 [tool.poetry.dependencies]
 backoff = "*"


### PR DESCRIPTION
Use Python 3.11 for building the release binaries.