### PR TITLE
Remove download_single

### DIFF
--- a/square/manio.py
+++ b/square/manio.py
@@ -13,7 +13,7 @@ import yaml.scanner
 import square.cfgfile
 import square.k8s
 from square.dtypes import (
-    Config, Filters, FiltersKind, GroupBy, K8sConfig, K8sResource, KindName,
+    Config, Filters, FiltersKind, GroupBy, K8sConfig, KindName,
     LocalManifestLists, MetaManifest, Selectors, SquareManifests,
 )
 from square.yaml_io import Dumper, Loader
@@ -1012,29 +1012,3 @@ async def _download_worker(config: Config, k8sconfig: K8sConfig, kind: str,
     except AssertionError:
         logit.error(f"Could not query <{kind}> from {k8sconfig.name}")
         return ({}, True)
-
-
-async def download_single(k8sconfig: K8sConfig,
-                          resource: K8sResource) -> Tuple[MetaManifest, dict, bool]:
-    """Similar to `download(...)` but only for a single Kubernetes `resource`.
-
-    Inputs:
-        k8sconfig: K8sConfig
-        resource: K8sResource
-
-    Returns:
-        MetaManifest, manifest: the K8s (meta)manifest.
-
-    """
-    try:
-        # Download the resource.
-        manifest, err = await square.k8s.get(k8sconfig.client, resource.url)
-        assert not err
-
-        manifest, err = strip(k8sconfig, manifest, {})
-        assert not err
-    except AssertionError:
-        logit.error(f"Could not query {k8sconfig.name} ({k8sconfig.url}/{resource.url})")
-        return (MetaManifest("", "", "", ""), {}, True)
-
-    return (make_meta(manifest), manifest, False)

--- a/square/square.py
+++ b/square/square.py
@@ -213,9 +213,14 @@ async def match_api_version(
         resource, err = k8s.resource(k8sconfig, meta)
         assert not err
 
-        # Download all resources of the current kind.
-        meta, manifest, err = await manio.download_single(k8sconfig, resource)
+        # Download the resource.
+        manifest, err = await k8s.get(k8sconfig.client, resource.url)
         assert not err
+
+        manifest, err = manio.strip(k8sconfig, manifest, {})
+        assert not err
+
+        meta = manio.make_meta(manifest)
 
         # Add the resource to the `server` dict. This will have been one of
         # those we deleted a few lines earlier.

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -2049,29 +2049,3 @@ class TestDownloadManifests:
         assert m_get.call_count == 2
         m_get.assert_any_call(k8sconfig.client, res_deploy.url)
         m_get.assert_any_call(k8sconfig.client, res_ns.url)
-
-    @mock.patch.object(k8s, 'get')
-    async def test_download_single(self, m_get, k8sconfig):
-        """Download a single manifest.
-
-        The test only mocks the K8s API call.
-
-        """
-        manifest = make_manifest("Deployment", "ns", "name")
-        meta = manio.make_meta(manifest)
-        assert meta == MetaManifest("apps/v1", "Deployment", "ns", "name")
-
-        # Mock the K8s response to return a valid manifest.
-        m_get.return_value = (manifest, False)
-
-        # Resource URLs.
-        res, err = resource(k8sconfig, meta)
-        assert not err
-
-        # Test function must successfully download the resource.
-        assert await manio.download_single(k8sconfig, res) == (meta, manifest, False)
-
-        # Simulate a download error.
-        m_get.return_value = (manifest, True)
-        ret = await manio.download_single(k8sconfig, res)
-        assert ret == (MetaManifest("", "", "", ""), {}, True)


### PR DESCRIPTION
Merge `download_single()` into `match_api_version()` since it is not used anywhere else.