### PR TITLE
Rework k8sconfig

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -72,9 +72,8 @@ class K8sConfig(NamedTuple):
     url: str = ""               # Kubernetes API
     token: str = ""             # Optional access token (eg Minikube).
 
-    # Certificate authority credentials and self signed client certificate.
-    # Used to authenticate to eg GKE.
-    ca_cert: Optional[Path] = None
+    # Certificate authority for self signed certificates.
+    cadata: Optional[str] = None
     client_cert: Optional[K8sClientCert] = None
 
     # HttpX client to access the cluster.

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from ssl import SSLContext
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple
 
 from pydantic import BaseModel, Field, field_validator
@@ -75,6 +76,7 @@ class K8sConfig(NamedTuple):
     # Certificate authority for self signed certificates.
     cadata: Optional[str] = None
     client_cert: Optional[K8sClientCert] = None
+    sslcontext: Optional[SSLContext] = None
 
     # HttpX client to access the cluster.
     client: Any = None

--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -77,6 +77,7 @@ class K8sConfig(NamedTuple):
     cadata: Optional[str] = None
     client_cert: Optional[K8sClientCert] = None
     sslcontext: Optional[SSLContext] = None
+    headers: Dict[str, str] = {}
 
     # HttpX client to access the cluster.
     client: Any = None

--- a/square/k8s.py
+++ b/square/k8s.py
@@ -503,11 +503,11 @@ def create_httpx_client(
         return k8sconfig, True
 
     # Add the bearer token if we have one.
-    if k8sconfig.token != "":
-        client.headers.update({'authorization': f'Bearer {k8sconfig.token}'})
+    headers = {'authorization': f'Bearer {k8sconfig.token}'} if k8sconfig.token else {}
+    client.headers.update(headers)
 
     # Add the web client to the `k8sconfig` object.
-    k8sconfig = k8sconfig._replace(client=client, sslcontext=sslcontext)
+    k8sconfig = k8sconfig._replace(client=client, sslcontext=sslcontext, headers=headers)
 
     # Return the configured client object.
     return k8sconfig, False

--- a/square/k8s.py
+++ b/square/k8s.py
@@ -483,7 +483,7 @@ def create_httpx_client(
 ) -> Tuple[K8sConfig, bool]:
     """Return configured HttpX client."""
     # Configure Httpx client with the K8s service account token.
-    ssl_context = ssl.create_default_context(cadata=k8sconfig.cadata)
+    sslcontext = ssl.create_default_context(cadata=k8sconfig.cadata)
 
     # Add the client certificate, if the cluster uses those to authenticate users.
     if k8sconfig.client_cert is not None:
@@ -493,7 +493,7 @@ def create_httpx_client(
 
     # Construct the HttpX client.
     try:
-        client = httpx.AsyncClient(verify=ssl_context, cert=cert)  # type: ignore
+        client = httpx.AsyncClient(verify=sslcontext, cert=cert)  # type: ignore
     except ssl.SSLError:
         logit.error("Invalid certificates")
         return k8sconfig, True
@@ -507,7 +507,7 @@ def create_httpx_client(
         client.headers.update({'authorization': f'Bearer {k8sconfig.token}'})
 
     # Add the web client to the `k8sconfig` object.
-    k8sconfig = k8sconfig._replace(client=client)
+    k8sconfig = k8sconfig._replace(client=client, sslcontext=sslcontext)
 
     # Return the configured client object.
     return k8sconfig, False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import unittest.mock as mock
 from pathlib import Path
 from typing import Generator
 
+import httpx
 import pytest
 
 import square.callbacks
@@ -36,7 +37,7 @@ def k8sconfig():
     # Return a valid K8sConfig with a subsection of API endpoints available in
     # Kubernetes v1.25.
     cadata = Path("tests/support/client.crt").read_text()
-    cfg = K8sConfig(version="1.25", client="k8s_client", cadata=cadata)
+    cfg = K8sConfig(version="1.25", client=httpx.AsyncClient(), cadata=cadata)
 
     # The set of API endpoints we can use in the tests.
     cfg.apis.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,8 @@ def kube_creds(request, k8sconfig) -> Generator[K8sConfig, None, None]:
 def k8sconfig():
     # Return a valid K8sConfig with a subsection of API endpoints available in
     # Kubernetes v1.25.
-    cfg = K8sConfig(version="1.25", client="k8s_client")
+    cadata = Path("tests/support/client.crt").read_text()
+    cfg = K8sConfig(version="1.25", client="k8s_client", cadata=cadata)
 
     # The set of API endpoints we can use in the tests.
     cfg.apis.clear()

--- a/tests/support/kubeconf.yaml
+++ b/tests/support/kubeconf.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority: ca.crt
+    certificate-authority: tests/support/client.crt
     server: https://192.168.0.177:8443
   name: minikube
 - cluster:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,7 +27,7 @@ except sh.CommandNotFound:
 
 @pytest.mark.skipif(not kind_available(), reason="No Integration Test Cluster")
 class TestBasic:
-    async def test_cluster_config(self):
+    async def test_cluster_config(self, k8sconfig):
         """Basic success/failure test for K8s configuration."""
         # Only show INFO and above or otherwise this test will produce a
         # humongous amount of logs from all the K8s calls.
@@ -44,7 +44,7 @@ class TestBasic:
         # Must not return a Kubernetes configuration if we could not create a
         # HttpX client.
         with mock.patch.object(square.k8s, "create_httpx_client") as m_client:
-            m_client.return_value = (httpx.AsyncClient(), True)
+            m_client.return_value = (k8sconfig, True)
             assert await fun(fname, None) == (K8sConfig(), True)
 
 

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -32,6 +32,7 @@ class TestK8sDeleteGetPatchPost:
         new_cfg, err = k8s.create_httpx_client(cfg)
         assert not err
         assert "authorization" not in new_cfg.client.headers
+        assert new_cfg.headers == {}
 
         # Create token based Kubernetes configuration.
         cfg = k8sconfig._replace(token="token")
@@ -40,6 +41,7 @@ class TestK8sDeleteGetPatchPost:
         assert isinstance(new_cfg.client, httpx.AsyncClient)
         assert isinstance(new_cfg.sslcontext, SSLContext)
         assert new_cfg.client.headers["authorization"] == "Bearer token"
+        assert new_cfg.headers == {"authorization": "Bearer token"}
 
         # Path to valid certificate specimen.
         fname_client_crt = Path("tests/support/client.crt")
@@ -52,6 +54,7 @@ class TestK8sDeleteGetPatchPost:
         assert isinstance(new_cfg.client, httpx.AsyncClient)
         assert isinstance(new_cfg.sslcontext, SSLContext)
         assert new_cfg.client.headers["authorization"] == "Bearer token"
+        assert new_cfg.headers == {"authorization": "Bearer token"}
 
     def test_create_httpx_client_err(self, k8sconfig, tmp_path: Path):
         """Must gracefully abort when there are certificate problems."""

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -13,7 +13,7 @@ import yaml
 
 import square.k8s as k8s
 import square.square
-from square.dtypes import K8sConfig, K8sResource, MetaManifest
+from square.dtypes import K8sConfig, K8sResource, MetaManifest, SSLContext
 
 from .test_helpers import kind_available
 
@@ -38,6 +38,7 @@ class TestK8sDeleteGetPatchPost:
         new_cfg, err = k8s.create_httpx_client(cfg)
         assert not err
         assert isinstance(new_cfg.client, httpx.AsyncClient)
+        assert isinstance(new_cfg.sslcontext, SSLContext)
         assert new_cfg.client.headers["authorization"] == "Bearer token"
 
         # Path to valid certificate specimen.
@@ -49,6 +50,7 @@ class TestK8sDeleteGetPatchPost:
         new_cfg, err = k8s.create_httpx_client(cfg)
         assert not err
         assert isinstance(new_cfg.client, httpx.AsyncClient)
+        assert isinstance(new_cfg.sslcontext, SSLContext)
         assert new_cfg.client.headers["authorization"] == "Bearer token"
 
     def test_create_httpx_client_err(self, k8sconfig, tmp_path: Path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -563,7 +563,7 @@ class TestMain:
     @mock.patch.object(main, "apply_plan")
     @mock.patch.object(sq.k8s, "cluster_config")
     async def test_main_valid_options(self, m_cluster, m_apply, m_plan, m_get,
-                                      fname_param_config, k8sconfig):
+                                      k8sconfig, fname_param_config):
         """Simulate sane program invocation.
 
         This test verifies that the bootstrapping works and the correct

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1149,6 +1149,8 @@ class TestMainOptions:
         The second part of the test simulates errors. This is not a separate
         test because it shares virtually all the boiler plate code.
         """
+        k8sconfig: K8sConfig = kube_creds
+
         # Valid MetaManifest.
         meta = manio.make_meta(make_manifest("Deployment", "ns", "name"))
 
@@ -1182,9 +1184,11 @@ class TestMainOptions:
         # corresponding calls to K8s.
         reset_mocks()
         assert await sq.apply_plan(config, plan) is False
-        m_post.assert_called_once_with("k8s_client", "create_url", {"create": "man"})
-        m_apply.assert_called_once_with("k8s_client", patch.url, patch.ops)
-        m_delete.assert_called_once_with("k8s_client", "delete_url", {"delete": "man"})
+        m_post.assert_called_once_with(k8sconfig.client, "create_url", {"create": "man"})
+        m_apply.assert_called_once_with(k8sconfig.client, patch.url, patch.ops)
+        m_delete.assert_called_once_with(
+            k8sconfig.client, "delete_url", {"delete": "man"}
+        )
 
         # -----------------------------------------------------------------
         #                   Simulate An Empty Plan


### PR DESCRIPTION
* Improve `K8sConfig` layout.
* Store the CA information in memory instead of creating an explicit temporary file.