### PR TITLE
bugfix: do not break with `null` arguments with authenticator apps.

### DIFF
--- a/square/k8s.py
+++ b/square/k8s.py
@@ -314,7 +314,11 @@ def load_authenticator_config(kubeconf_path: Path,
         return (K8sConfig(), True)
 
     # Convert a `None` to an empty list of env vars.
+    # This happens when the kubeconfig file contains entries like `args: null`
+    # in the YAML which will then be parsed as None in Python yet we need them
+    # to be an empty list.
     env_kubeconf = env_kubeconf if env_kubeconf else []
+    args = args if args else []
 
     # Compile the name, arguments and env vars for the command specified in kubeconf.
     cmd_args = [cmd] + args

--- a/tests/support/kubeconf.yaml
+++ b/tests/support/kubeconf.yaml
@@ -70,12 +70,7 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
-      args:
-      - get-token
-      - --login
-      - azurecli
-      - --server-id
-      - abc123
+      args: null
       command: kubelogin
       env: null
       provideClusterInfo: false

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1068,7 +1068,7 @@ class TestK8sKubeconfig:
         # environment variables. The "expected_*" values are directly from
         # "support/kubeconf.yaml".
         if context == "aks":
-            args = ["get-token", "--login", "azurecli", "--server-id", "abc123"]
+            args = []
             env = {}
         elif context == "eks":
             args = ["token", "-i", "eks-cluster-name"]


### PR DESCRIPTION
Square now accepts `users[].user.exec.args: null` in the Kubeconfig YAML.