### PR TITLE
Feat use JSON path filters

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Set, Tuple
 
+import jsonpath_ng as jp
+from jsonpath_ng.exceptions import JsonPathParserError
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Annotated
@@ -286,6 +288,9 @@ class ConnectionParameters(BaseModel):
 FiltersKind = List[str | dict]
 Filters = Dict[str, FiltersKind]  # eg {"Deployment": ["spec.replicas"]}
 
+"""Define the new-style filters using JSON path strings."""
+Filters2 = Dict[str, List[str]]  # eg {"Deployment": [".spec.replicas"]}
+
 
 # Workaround for a circular import with `callbacks`. The `callbacks` module
 # needs the `Config` type annotation but `dtypes.Config` needs the callbacks.
@@ -318,8 +323,11 @@ class Config(BaseModel):
     # How to structure the folder directory when syncing manifests.
     groupby: GroupBy = GroupBy()
 
-    # Define which fields to skip for which resource.
+    # Define which fields to skip for which resource (legacy nested dict format).
     filters: Filters = {}
+
+    # Define which fields to skip for which resource (new JSON path format).
+    filters2: Filters2 = {}
 
     # Connection timeouts, headers and extra SSL configurations.
     connection_parameters: ConnectionParameters = ConnectionParameters()
@@ -333,6 +341,11 @@ class Config(BaseModel):
     # Invoked for every manifest downloaded from cluster.
     strip_callback: Annotated[Callable, Field(validate_default=True)] = do_nothing
 
+    class Config:
+        # Pydantic config: ensure that all fields are validated on assignment,
+        # not just at initialisation.
+        validate_assignment = True
+
     @field_validator("filters")
     @classmethod
     def validate_filters(cls, filters: Filters) -> Filters:
@@ -343,6 +356,30 @@ class Config(BaseModel):
                 raise ValueError(f"Dict key <{k}> must be a non-empty string")
             validate_subfilters(v)
         return filters
+
+    @field_validator("filters2")
+    @classmethod
+    def validate_filters2(cls, filters2: Filters2) -> Filters2:
+        """Ensure the keys denote valid resource types and the values are valid
+        JSON paths.
+
+        Returns the original `filters2` dict with all the keys lowercased for
+        easier matching and consistency later on.
+
+        """
+        for key, paths in filters2.items():
+            # Run Pydantic validation on the key (eg "Deployment") to ensure it
+            # is a valid `SelKindGroupNames` string.
+            SelKindGroupNames(value=key)
+
+            try:
+                for path in paths:
+                    jp.parse(path)
+            except JsonPathParserError:
+                raise ValueError(f"Path <{path}> is not a valid JSON path")
+
+        lower = {k.lower(): v for k, v in filters2.items()}
+        return lower
 
     @field_validator("patch_callback")
     @classmethod

--- a/square/main.py
+++ b/square/main.py
@@ -325,6 +325,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
     # Use filters from (default) config file because they cannot be specified
     # on the command line.
     filters = cfg.filters
+    filters2 = cfg.filters2
 
     # ------------------------------------------------------------------------
     # Verify inputs.
@@ -345,6 +346,7 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
         groupby=groupby,
         priorities=priorities,
         filters=filters,
+        filters2=filters2,
         connection_parameters=cfg.connection_parameters,
     )
     return cfg, False

--- a/square/manio.py
+++ b/square/manio.py
@@ -12,9 +12,9 @@ import yaml.scanner
 
 import square.k8s
 import square.square
+import square.manio_filters
 from square.dtypes import (
     Config,
-    FiltersKind,
     GroupBy,
     K8sConfig,
     LocalManifestLists,
@@ -518,65 +518,18 @@ def diff(local: dict, server: dict) -> Tuple[str, bool]:
 
 
 def strip_manifest(config: Config, manifest: dict) -> dict:
-    def _update(filters: FiltersKind, manifest: dict):
-        """Recursively traverse the `manifest` and prune it according to `filters`.
+    kind = manifest["kind"].lower()
+    group = manifest["apiVersion"].split("/")[0]
+    kg = SelKindGroupNames(value=f"{kind.lower()}.{group}").kind_group
 
-        Returns the input `manifest` but with the excluded sections.
+    # print(kg, kind, config.filters2)
+    filters = config.filters2.get("_common_", [])
+    filters += config.filters2.get(kg, []) + config.filters2.get(kind, [])
+    filters = list(set(filters))
 
-        Raise `KeyError` if an invalid key was found.
-
-        """
-        # Split the list of strings and dicts into a dedicated set of string
-        # and dedicated list of dicts.
-        # Example: ["foo", "bar", {"a": "b", "c": "d"}] will become
-        #   {"foo", "bar"} and {"a": "b", "c", "d"}.
-        filter_str = {_ for _ in filters if isinstance(_, str)}
-        filter_map = [_ for _ in filters if isinstance(_, dict)]
-        filter_map = {k: v for d in filter_map for k, v in d.items()}
-
-        # Iterate over the manifest. Prune all keys that match the `filters`
-        # and record them in `removed`.
-        removed = {}
-        for k, v in list(manifest.items()):
-            if k in filter_str:
-                # Remove the entire key (and all sub-fields if present).
-                # NOTE: it does not matter if the key also exists in
-                # `filter_map` - we remove the entire key.
-                logit.debug(f"Remove <{k}>")
-                removed[k] = manifest.pop(k)
-            elif isinstance(v, list) and k in filter_map:
-                # Recursively filter each list element.
-                tmp = [_update(filter_map[k], _) for _ in v]
-                removed[k] = [_ for _ in tmp if _]
-
-                # Do not leave empty elements in the list.
-                manifest[k] = [_ for _ in v if _]
-            elif isinstance(v, dict) and k in filter_map:
-                # Recursively filter each dictionary element.
-                logit.debug(f"Dive into <{k}>")
-                removed[k] = _update(filter_map[k], manifest[k])
-            else:
-                logit.debug(f"Skip <{k}>")
-
-            # Remove the key from the manifest altogether if it has become empty.
-            if not manifest.get(k, "non-empty"):
-                del manifest[k]
-
-        # Remove all empty sub-dictionaries from `removed`.
-        return {k: v for k, v in removed.items() if v != {}}
-
-    # Look up the filters for the current resource in the following order:
-    # 1) Supplied `manifest_filters`
-    # 2) Square default filters for this resource `kind`.
-    # Pick the first one that matches.
-    kind = manifest["kind"]
-
-    default_filter = square.DEFAULT_CONFIG.filters["_common_"]
-    filters: FiltersKind = config.filters.get(kind, default_filter)
-
-    # Remove the keys from the `manifest` according to `filters`.
-    _update(filters, manifest)
-    return manifest
+    out, err = square.manio_filters.strip_manifest_paths(manifest, filters)
+    assert not err, "bug: filters should have been validated beforehand"
+    return out
 
 
 def strip_manifests(

--- a/square/resources/defaultconfig.yaml
+++ b/square/resources/defaultconfig.yaml
@@ -131,3 +131,34 @@ filters:
       - ports:
         - nodePort
       - sessionAffinity
+
+filters2:
+  # --- These will be inserted into all resource types to reduce boiler plate. ---
+  _common_:
+    - metadata.annotations["autoscaling.alpha.kubernetes.io/conditions"]
+    - metadata.annotations["deployment.kubernetes.io/revision"]
+    - metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]
+    - metadata.annotations["kubernetes.io/change-cause"]
+    - metadata.creationTimestamp
+    - metadata.generation
+    - metadata.managedFields
+    - metadata.resourceVersion
+    - metadata.selfLink
+    - metadata.uid
+    - status
+
+  # --- Individual resource types. ---
+  configmap:
+    - metadata.annotations
+
+  deployment.apps: []
+
+  horizontalpodautoscaler.autoscaling:
+    - metadata.annotations["autoscaling.alpha.kubernetes.io/conditions"]
+    - metadata.annotations["autoscaling.alpha.kubernetes.io/current-metrics"]
+    - metadata.annotations["control-plane.alpha.kubernetes.io/leader"]
+
+  service:
+    - spec.clusterIP
+    - spec.ports[*].nodePort
+    - spec.sessionAffinity

--- a/tests/support/config.yaml
+++ b/tests/support/config.yaml
@@ -106,3 +106,34 @@ filters:
     - spec:
       - ports:
         - nodePort
+
+filters2:
+  # --- These will be inserted into all resource types to reduce boiler plate. ---
+  _common_:
+    - metadata.annotations["autoscaling.alpha.kubernetes.io/conditions"]
+    - metadata.annotations["deployment.kubernetes.io/revision"]
+    - metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]
+    - metadata.annotations["kubernetes.io/change-cause"]
+    - metadata.creationTimestamp
+    - metadata.generation
+    - metadata.managedFields
+    - metadata.resourceVersion
+    - metadata.selfLink
+    - metadata.uid
+    - status
+
+  # --- Individual resource types. ---
+  configmap:
+    - metadata.annotations
+
+  deployment.apps: []
+
+  horizontalpodautoscaler.autoscaling:
+    - metadata.annotations["autoscaling.alpha.kubernetes.io/conditions"]
+    - metadata.annotations["autoscaling.alpha.kubernetes.io/current-metrics"]
+    - metadata.annotations["control-plane.alpha.kubernetes.io/leader"]
+
+  service:
+    - spec.clusterIP
+    - spec.ports[*].nodePort
+    - spec.sessionAffinity

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,7 +1,9 @@
+from pathlib import Path
 import pydantic
 import pytest
 
 from square.dtypes import (
+    Config,
     MetaManifest,
     Selectors,
     SelKindGroupNames,
@@ -210,3 +212,79 @@ class TestSelectors:
 
         meta = MetaManifest("", "Pod", None, "")
         assert meta.skgn() == SKGN(value="pod", ns="")
+
+
+class TestConfigFilters2:
+    """Tests for the filters2 field validator on Config."""
+
+    def make_config(self, filters2):
+        """Helper to construct a minimal Config with the given filters2."""
+        return Config(
+            folder=Path("/tmp"),
+            kubeconfig=Path("/tmp/kubeconfig"),
+            filters2=filters2,
+        )
+
+    def test_filters2_empty(self):
+        """An empty filters2 dict is valid."""
+        cfg = self.make_config({})
+        assert cfg.filters2 == {}
+
+    def test_filters2_valid_simple(self):
+        """Valid filters2 with simple JSON paths."""
+        filters = {
+            "deployment": ["metadata.labels", "spec.replicas"],
+            "service": ["spec.clusterIP"],
+        }
+        cfg = self.make_config(filters)
+        assert cfg.filters2 == filters
+
+    def test_filters2_valid_lowercase_manual_assign(self):
+        """The filters must be lower-cased upon import as well as when directly
+        assigned to the `.filters` attribute.
+
+        """
+        # Import.
+        cfg = self.make_config({"DEPLOYMENT": [], "Service": []})
+        assert cfg.filters2 == {"deployment": [], "service": []}
+
+        # Assign values directly.
+        cfg.filters2 = {"FOO": [], "BAR": []}
+        assert cfg.filters2 == {"foo": [], "bar": []}
+
+    def test_filters2_valid_empty_path_list(self):
+        """A valid key with an empty list of paths is allowed."""
+        cfg = self.make_config({"deployment": []})
+        assert cfg.filters2 == {"deployment": []}
+
+    def test_filters2_valid_complex_paths(self):
+        """Valid filters2 with array wildcard and nested paths."""
+        filters = {
+            "deployment": [
+                "spec.containers[*].env",
+                "metadata.annotations['kubernetes.io/last-applied-configuration']",
+            ],
+        }
+        cfg = self.make_config(filters)
+        assert cfg.filters2 == filters
+
+    def test_filters2_invalid_key(self):
+        """An invalid SelKindGroupNames key must raise a ValidationError."""
+        invalid_keys = [
+            "",  # empty string
+            "/name",  # no kind
+            "pod.apps/",  # empty name after slash
+        ]
+        for key in invalid_keys:
+            with pytest.raises(pydantic.ValidationError):
+                self.make_config({key: [".metadata.name"]})
+
+    def test_filters2_invalid_path(self):
+        """An invalid JSON path must raise a ValidationError."""
+        with pytest.raises(pydantic.ValidationError):
+            self.make_config({"deployment": ["]$0metadata.labels"]})
+
+    def test_filters2_valid_key_with_group(self):
+        """A key with an explicit API group is valid."""
+        cfg = self.make_config({"role.rbac.authorization.k8s.io": ["metadata.labels"]})
+        assert "metadata.labels" in cfg.filters2["role.rbac.authorization.k8s.io"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,6 +30,25 @@ except sh.CommandNotFound:
     kubectl = None
 
 
+def add_default_filters(config: Config) -> None:
+    if "_common_" in config.filters2:
+        return
+
+    config.filters2["_common_"] = [
+        'metadata.annotations["autoscaling.alpha.kubernetes.io/conditions"]',
+        'metadata.annotations["deployment.kubernetes.io/revision"]',
+        'metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]',
+        'metadata.annotations["kubernetes.io/change-cause"]',
+        "metadata.creationTimestamp",
+        "metadata.generation",
+        "metadata.managedFields",
+        "metadata.resourceVersion",
+        "metadata.selfLink",
+        "metadata.uid",
+        "status",
+    ]
+
+
 @contextmanager
 def create_temporary_k8s_namespace():
     ts = int(1000 * time.time())
@@ -358,6 +377,7 @@ class TestMainGet:
                 labels=[],
             ),
         )
+        add_default_filters(config)
 
         # Copy the manifest with the namespace and HPAs to a temporary path.
         manifests = list(yaml.safe_load_all(open("tests/support/k8s-test-hpa.yaml")))
@@ -779,6 +799,7 @@ class TestMainPlan:
                 labels=["app=test-workflow"],
             ),
         )
+        add_default_filters(config)
 
         # ---------------------------------------------------------------------
         # Deploy a new namespace with only a few resources. There are no
@@ -857,6 +878,7 @@ class TestMainPlan:
                 kinds={"HorizontalPodAutoscaler"}, namespaces=["test-hpa"], labels=[]
             ),
         )
+        add_default_filters(config)
 
         # Copy the manifest with the namespace and the two HPAs to the temporary path.
         manifests = list(yaml.safe_load_all(open("tests/support/k8s-test-hpa.yaml")))
@@ -988,6 +1010,7 @@ class TestCRUD:
                     kinds={kind}, namespaces=[ns], labels=["app=test-kind-group-v1"]
                 ),
             )
+            add_default_filters(config)
 
             # ------------------------------------------------------------------
             # Deploy one instance of each CRD with `kubectl`.
@@ -1073,6 +1096,7 @@ class TestCRUD:
                     labels=[],
                 ),
             )
+            add_default_filters(config)
 
             # ------------------------------------------------------------------
             # Deploy one instance of each CRD with `kubectl`.

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -890,7 +890,7 @@ class TestStripManifest:
         # present in the original.
         # ----------------------------------------------------------------------
         man_loc["metadata"]["annotations"] = {"foo": "bar"}
-        sqcfg.filters = {"ClusterRole": [{"metadata": ["annotations"]}]}
+        sqcfg.filters2 = {"Clusterrole": ["metadata.annotations"]}
         ret_loc, ret_srv, err = fun(sqcfg, local, server)
         assert not err
 
@@ -1849,6 +1849,7 @@ class TestManifestStripping:
             {"spec": [{"ports": ["nodePort"]}]},
         ]
         sqcfg.filters = {"Service": _filters}
+        sqcfg.filters2 = {"service": ["metadata.labels.foo", "status"]}
 
         # Demo manifest. None of its keys matches the filter and
         # `strip` must therefore not remove anything.
@@ -1868,7 +1869,7 @@ class TestManifestStripping:
             "metadata": {
                 "name": "name",
                 "namespace": "ns",
-                "labels": {"foo": "remove"},
+                "labels": {"foo": "remove", "bar": "keep"},
             },
             "spec": "spec",
         }
@@ -1878,6 +1879,7 @@ class TestManifestStripping:
             "metadata": {
                 "name": "name",
                 "namespace": "ns",
+                "labels": {"bar": "keep"},
             },
             "spec": "spec",
         }
@@ -2014,24 +2016,6 @@ class TestManifestStripping:
         assert manio.strip_manifest(sqcfg, manifest) == expected
 
         manifest["status"] = {"foo", "bar"}
-        assert manio.strip_manifest(sqcfg, manifest) == expected
-
-    def test_strip_manifest_lists_simple(self, sqcfg: Config):
-        """Filter the `NodePort` key from a list of dicts."""
-        # Filter the "nodePort" element from the port list.
-        sqcfg.filters = {"Service": [{"spec": [{"ports": ["nodePort"]}]}]}
-
-        expected = {
-            "apiVersion": "v1",
-            "kind": "Service",
-            "metadata": {"name": "name", "namespace": "ns"},
-            "spec": {"type": "NodePort"},
-        }
-        manifest = cast(dict, copy.deepcopy(expected))
-        manifest["spec"]["ports"] = [
-            {"nodePort": 1},
-            {"nodePort": 3},
-        ]
         assert manio.strip_manifest(sqcfg, manifest) == expected
 
     def test_strip_manifest_lists_service(self, sqcfg: Config):


### PR DESCRIPTION
Introduce a new `Config.filters2` that represent JSON path strings and use them. The `Config.filters` is still present but partially defunct at this point. This contributes towards the JSON path filters goal but it not yet fully functional. The performance is also terrible for now.