### PR TITLE
bugfix(manio): prevent mutation of filters in `strip_single_manifest`.

### DIFF
--- a/square/manio.py
+++ b/square/manio.py
@@ -532,7 +532,7 @@ def strip_single_manifest(config: Config, manifest: dict) -> dict:
     # Fetch the filters for this GVK. The user may have specified them via
     # their short or full names, eg "deploy" or "deploy.apps". We need to check
     # for both to cover all bases.
-    filters = config.filters.get("_common_", [])
+    filters = list(config.filters.get("_common_", []))
     filters += config.filters.get(kg, []) + config.filters.get(kind, [])
     filters = list(set(filters))
 

--- a/tests/test_manio.py
+++ b/tests/test_manio.py
@@ -1856,3 +1856,30 @@ class TestManifestStripping:
             },
         }
         assert manio.strip_single_manifest(sqcfg, manifest) == expected
+
+    def test_strip_single_manifest_bug(self, sqcfg: Config):
+        """Test a specific bug where the list of filters was mutated.
+
+        The root cause of the bug was that `strip_manifest_paths` created an
+        auxiliary list of filters that was not a copy of the original list but
+        a reference. As a consequence, the original list of filters was mutated
+        and changed for all subsequent calls to `strip_single_manifest`.
+
+        """
+        # Define filters for this test.
+        sqcfg.filters = {
+            "service": ["metadata.labels.foo"],
+            "service.v1": ["metadata.labels.bar"],
+            "_common_": ["metadata.labels.foobar"],
+        }
+
+        # Minimal manifest. Content is irrelevant for this test since we only
+        # want to verify that the filters are not mutated.
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Service",
+        }
+        manio.strip_single_manifest(sqcfg, manifest)
+        assert len(sqcfg.filters["service"]) == 1
+        assert len(sqcfg.filters["service.v1"]) == 1
+        assert len(sqcfg.filters["_common_"]) == 1


### PR DESCRIPTION
- Ensure filters are copied before modification to avoid side effects
- Add test to verify config filters remain unchanged after function call