### PR TITLE
refactor: store filters as strings only.

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -1,3 +1,4 @@
+from functools import cache
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Set, Tuple
 
@@ -285,7 +286,7 @@ class ConnectionParameters(BaseModel):
 
 
 """Define the new-style filters using JSON path strings."""
-Filters = Dict[str, List[str | jp.JSONPath]]  # eg {"Deployment": [".spec.replicas"]}
+Filters = Dict[str, List[str]]  # eg {"Deployment": [".spec.replicas"]}
 
 
 # Workaround for a circular import with `callbacks`. The `callbacks` module
@@ -295,6 +296,12 @@ Filters = Dict[str, List[str | jp.JSONPath]]  # eg {"Deployment": [".spec.replic
 # ctor at runtime.
 def do_nothing():
     return  # codecov-skip
+
+
+@cache
+def jpcache(p: str) -> jp.JSONPath:
+    """Parse a JSONPath expression and cache the result."""
+    return jp.parse(p)
 
 
 class Config(BaseModel):
@@ -355,20 +362,16 @@ class Config(BaseModel):
         #
         # Compilation occurs during validation so that runtime access operates solely
         # on pre-parsed expressions, avoiding repeated parsing overhead.
-        out: Dict[str, List[str | jp.JSONPath]] = {}
-        for key, paths in filters.items():
-            key = key.lower()
-            out[key] = []
-
-            # Run Pydantic validation on the key (eg "Deployment") to ensure it
-            # is a valid `SelKindGroupNames` string.
+        out = {k.lower(): v for k, v in filters.items()}
+        for key, paths in out.items():
+            # Run Pydantic validation on the key (eg "Deployment").
             SelKindGroupNames(value=key)
 
             try:
                 for path in paths:
-                    out[key].append(jp.parse(path) if isinstance(path, str) else path)
+                    jpcache(path)
             except JsonPathParserError:
-                raise ValueError(f"Path <{path}> is not a valid JSON path")
+                raise ValueError(f"invalid JSON path <{path}>")
 
         return out
 

--- a/square/manio.py
+++ b/square/manio.py
@@ -5,12 +5,11 @@ import difflib
 import logging
 import multiprocessing
 from pathlib import Path
-from typing import DefaultDict, Dict, Iterable, List, Tuple, cast
+from typing import DefaultDict, Dict, Iterable, List, Tuple
 
 import yaml.parser
 import yaml.scanner
 
-import jsonpath_ng as jp
 import square.k8s
 import square.square
 import square.manio_filters
@@ -532,15 +531,11 @@ def strip_single_manifest(config: Config, manifest: dict) -> dict:
     # Fetch the filters for this GVK. The user may have specified them via
     # their short or full names, eg "deploy" or "deploy.apps". We need to check
     # for both to cover all bases.
-    filters = list(config.filters.get("_common_", []))
-    filters += config.filters.get(kg, []) + config.filters.get(kind, [])
-    filters = list(set(filters))
+    f = config.filters
+    paths = f.get("_common_", []) + f.get(kg, []) + f.get(kind, [])
+    paths = list(set(paths))
 
-    # Sleight of hand (cf `dtypes.Config.validate_filters`) to satisfy MyPy
-    # that `filters` is indeed a List[jp.JSONPath] and will never contain
-    # any strings.
-    filters = cast(List[jp.JSONPath], filters)
-    return square.manio_filters.strip_manifest_paths(manifest, filters)
+    return square.manio_filters.strip_manifest_paths(manifest, paths)
 
 
 def strip_manifests(

--- a/square/manio_filters.py
+++ b/square/manio_filters.py
@@ -1,4 +1,5 @@
 import copy
+import square.dtypes
 from typing import Any, Dict, List
 
 import jsonpath_ng as jp
@@ -56,9 +57,7 @@ def _delete_match(jpmatch: jp.DatumInContext) -> None:
         del parent[i]
 
 
-def strip_manifest_paths(
-    manifest: Dict[str, Any], paths: List[jp.JSONPath]
-) -> Dict[str, Any]:
+def strip_manifest_paths(manifest: Dict[str, Any], paths: List[str]) -> Dict[str, Any]:
     """
     Remove specified JSONPath paths from a Kubernetes manifest.
 
@@ -77,8 +76,9 @@ def strip_manifest_paths(
     # Collect all matches across all expressions, then sort by index descending
     # so that deleting array elements by index doesn't shift subsequent indices.
     all_matches: List[jp.DatumInContext] = []
+    jpathcache = square.dtypes.jpcache
     for path in paths:
-        all_matches.extend(path.find(manifest))
+        all_matches.extend(jpathcache(path).find(manifest))
     all_matches.sort(key=lambda m: str(m.full_path), reverse=True)
 
     for jpmatch in all_matches:

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import pydantic
 import pytest
-import jsonpath_ng as jp
 
 from square.dtypes import (
     Config,
@@ -238,7 +237,7 @@ class TestConfigFilters:
             "service": ["spec.clusterIP"],
         }
         cfg = self.make_config(filters)
-        assert cfg.filters == {k: [jp.parse(_) for _ in v] for k, v in filters.items()}
+        assert cfg.filters == filters
 
     def test_filters_valid_lowercase_manual_assign(self):
         """The filters must be lower-cased upon import as well as when directly
@@ -267,7 +266,7 @@ class TestConfigFilters:
             ],
         }
         cfg = self.make_config(filters)
-        assert cfg.filters == {k: [jp.parse(_) for _ in v] for k, v in filters.items()}
+        assert cfg.filters == filters
 
     def test_filters_invalid_key(self):
         """An invalid SelKindGroupNames key must raise a ValidationError."""
@@ -289,4 +288,4 @@ class TestConfigFilters:
         """A key with an explicit API group is valid."""
         res = "role.rbac.authorization.k8s.io"
         cfg = self.make_config({res: ["metadata.labels"]})
-        assert jp.parse("metadata.labels") in cfg.filters[res]
+        assert "metadata.labels" in cfg.filters[res]

--- a/tests/test_manio_filters.py
+++ b/tests/test_manio_filters.py
@@ -1,5 +1,4 @@
 from square.manio_filters import strip_manifest_paths, remove_empty_dicts
-import jsonpath_ng as jp
 
 # ---------------------------------------------------------------------------
 # Tests for remove_empty_dicts
@@ -123,7 +122,7 @@ def test_basic_stripping():
         "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]},
     }
 
-    result = strip_manifest_paths(manifest, [jp.parse("metadata.labels")])
+    result = strip_manifest_paths(manifest, ["metadata.labels"])
     assert result == {
         "apiVersion": "v1",
         "kind": "Pod",
@@ -143,7 +142,7 @@ def test_array_index_stripping():
         }
     }
 
-    result = strip_manifest_paths(manifest, [jp.parse("spec.containers[1]")])
+    result = strip_manifest_paths(manifest, ["spec.containers[1]"])
     assert result == {
         "spec": {
             "containers": [
@@ -165,7 +164,7 @@ def test_array_index_stripping_multi():
         }
     }
 
-    paths = [jp.parse("spec.containers[0]"), jp.parse("spec.containers[2]")]
+    paths = ["spec.containers[0]", "spec.containers[2]"]
     result = strip_manifest_paths(manifest, paths)
     assert result == {
         "spec": {"containers": [{"name": "nginx", "image": "nginx:latest"}]}
@@ -182,7 +181,7 @@ def test_wildcard_stripping():
         }
     }
 
-    paths = [jp.parse("spec.containers[*].env")]
+    paths = ["spec.containers[*].env"]
     result = strip_manifest_paths(manifest, paths)
     assert result == {
         "spec": {
@@ -202,7 +201,7 @@ def test_nested_path_stripping():
         }
     }
 
-    paths = [jp.parse("metadata.annotations.key1")]
+    paths = ["metadata.annotations.key1"]
     result = strip_manifest_paths(manifest, paths)
     assert result == {
         "metadata": {
@@ -224,7 +223,7 @@ def test_multiple_paths_stripping():
         "spec": {"containers": [{"name": "nginx"}], "replicas": 3},
     }
 
-    paths = [jp.parse("metadata.labels"), jp.parse("spec.replicas")]
+    paths = ["metadata.labels", "spec.replicas"]
     result = strip_manifest_paths(manifest, paths)
     assert result == {
         "apiVersion": "v1",
@@ -247,7 +246,7 @@ def test_multiple_paths_stripping2():
         },
     }
 
-    paths = [jp.parse("metadata.labels"), jp.parse("metadata.labels.app")]
+    paths = ["metadata.labels", "metadata.labels.app"]
     result = strip_manifest_paths(manifest, paths)
     assert result == {
         "apiVersion": "v1",
@@ -259,13 +258,13 @@ def test_multiple_paths_stripping2():
 
 
 def test_empty_manifest():
-    result = strip_manifest_paths({}, [jp.parse("metadata")])
+    result = strip_manifest_paths({}, ["metadata"])
     assert result == {}
 
 
 def test_nonexistent_path():
     manifest = {"metadata": {"name": "test"}}
-    result = strip_manifest_paths(manifest, [jp.parse("metadata.labels")])
+    result = strip_manifest_paths(manifest, ["metadata.labels"])
     assert result == manifest
 
 
@@ -306,7 +305,6 @@ def test_complex_k8s_manifest():
         "spec.replicas",
         "metadata.labels['kubernetes.io/name']",
     ]
-    paths = [jp.parse(p) for p in paths]
     result = strip_manifest_paths(manifest, paths)
     assert result == {
         "apiVersion": "apps/v1",


### PR DESCRIPTION
Also cache the compiled JSON path objects because they are expensive to compute.