### PR TITLE
refactor: rename `compile_config` -> `update_config`.

### DIFF
--- a/square/square.py
+++ b/square/square.py
@@ -78,7 +78,7 @@ def normalise_kinds(
     return (normalised_kinds, False)
 
 
-def compile_config(cfg: Config, k8sconfig: K8sConfig) -> Tuple[Config, bool]:
+def update_config(cfg: Config, k8sconfig: K8sConfig) -> Tuple[Config, bool]:
     """Convert `cfg.Selectors.kind` and `cfg.priorities` to Square internal format.
 
     Examples:
@@ -788,7 +788,7 @@ async def apply_plan(cfg: Config, plan: DeploymentPlan) -> bool:
     )
 
     # Convert "Selectors.kinds" to their canonical names.
-    cfg, compile_err = compile_config(cfg, k8sconfig)
+    cfg, compile_err = update_config(cfg, k8sconfig)
 
     # Abort if we could not get the plan or establish the K8s session.
     if plan_err or k8s_err or compile_err:
@@ -897,7 +897,7 @@ async def make_plan(cfg: Config) -> Tuple[DeploymentPlan, bool]:
         assert not err
 
         # Convert "Selectors.kinds" to their canonical names.
-        cfg, err = compile_config(cfg, k8sconfig)
+        cfg, err = update_config(cfg, k8sconfig)
         assert not err
 
         # Load manifests from local files.
@@ -949,7 +949,7 @@ async def get_resources(cfg: Config) -> bool:
         # NOTE: we cannot do this earlier, eg as part of the Pydantic model
         # because we need access to K8s first so that `k8sconfig` contains all
         # the API resources and groups.
-        cfg, err = compile_config(cfg, k8sconfig)
+        cfg, err = update_config(cfg, k8sconfig)
         assert not err
 
         # Use a wildcard Selector to ensure `manio.load` will read _all_ local

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -193,7 +193,7 @@ class TestBasic:
             selectors=Selectors(kinds={"svc", "deploy/name"}),
         )
 
-        got_cfg, err = sq.compile_config(cfg, k8sconfig)
+        got_cfg, err = sq.update_config(cfg, k8sconfig)
         assert not err
 
         # Must have normalised the kinds and preserved the optional name. It
@@ -211,7 +211,7 @@ class TestBasic:
             priorities=["ns/name"],
             selectors=Selectors(kinds=set()),
         )
-        _, err = sq.compile_config(cfg, k8sconfig)
+        _, err = sq.update_config(cfg, k8sconfig)
         assert err
 
         # Invalid: priority list must not contain duplicates.
@@ -223,7 +223,7 @@ class TestBasic:
             priorities=["ns", "ns"],
             selectors=Selectors(kinds=set()),
         )
-        _, err = sq.compile_config(cfg, k8sconfig)
+        _, err = sq.update_config(cfg, k8sconfig)
         assert err
 
         # Invalid: selected kind does not exist in current K8s cluster.
@@ -235,7 +235,7 @@ class TestBasic:
             priorities=[],
             selectors=Selectors(kinds={"unknown"}),
         )
-        _, err = sq.compile_config(cfg, k8sconfig)
+        _, err = sq.update_config(cfg, k8sconfig)
         assert err
 
     def test_valid_label(self):
@@ -815,7 +815,7 @@ class TestPlan:
         )
 
         sqcfg.priorities = ["Namespace", "Service", "Deployment"]
-        sqcfg, err = sq.compile_config(sqcfg, k8sconfig)
+        sqcfg, err = sq.update_config(sqcfg, k8sconfig)
         assert not err
         plan = copy.deepcopy(expected)
         for _ in range(10):
@@ -852,7 +852,7 @@ class TestPlan:
             ],
         )
         sqcfg.priorities = ["Namespace", "Deployment"]
-        sqcfg, err = sq.compile_config(sqcfg, k8sconfig)
+        sqcfg, err = sq.update_config(sqcfg, k8sconfig)
         assert not err
         plan = copy.deepcopy(expected)
         for _ in range(10):


### PR DESCRIPTION
A different function with same name already exists in a different module.