### PR TITLE
Update kubectl, kind, and node image versions for tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,8 +25,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           mkdir ~/bin
-          curl -L --output ~/bin/kubectl https://dl.k8s.io/release/v1.34.2/bin/linux/amd64/kubectl
-          curl -L --output ~/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64
+          curl -L --output ~/bin/kubectl https://dl.k8s.io/release/v1.36.0/bin/linux/amd64/kubectl
+          curl -L --output ~/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.31.0/kind-linux-amd64
           chmod +x ~/bin/kubectl ~/bin/kind
 
           cd ./integration-test-cluster

--- a/integration-test-cluster/start_cluster.sh
+++ b/integration-test-cluster/start_cluster.sh
@@ -15,7 +15,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0
+  image: kindest/node:v1.35.0
 EOF
 
 # Create cluster, then delete its config file.


### PR DESCRIPTION
- Bump kubectl to v1.36.0 and kind to v0.31.0 in CI workflow
- Update kindest/node image to v1.35.0 in cluster startup script