### PR TITLE
bugfix: order API versions numerically in the pick heuristic

### DIFF
--- a/square/k8s.py
+++ b/square/k8s.py
@@ -1024,9 +1024,12 @@ def pick_api(
     alpha = [ver for ver in api_dict if p_alpha.match(ver)]
     beta = [ver for ver in api_dict if p_beta.match(ver)]
 
-    stable.sort()
-    alpha.sort()
-    beta.sort()
+    # Sort each tier by its numeric components so that eg "v10" ranks above
+    # "v2" (a plain string sort would order them lexicographically). The regexes
+    # above guarantee every entry consists solely of the digits we parse here.
+    stable.sort(key=lambda ver: int(ver[1:]))
+    alpha.sort(key=lambda ver: tuple(int(part) for part in ver[1:].split("alpha")))
+    beta.sort(key=lambda ver: tuple(int(part) for part in ver[1:].split("beta")))
     if len(stable) > 0:
         pick = api_dict[stable[-1]]
         logit.info(f"Picked {pick.apiVersion} for <{name}>")

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1209,6 +1209,42 @@ class TestUrlPathBuilder:
         got, err = k8s.pick_api(meta, apis)
         assert not err and got is r_foo_v2
 
+    def test_pick_api_double_digit_versions(self):
+        """The version heuristic must order version numbers numerically.
+
+        A lexicographic sort ranks "v2" above "v10"; the heuristic must pick the
+        numerically highest version in each of the stable, beta and alpha tiers.
+
+        """
+        r_foo = K8sResource(
+            apiVersion="api-a.com/v1",
+            kind="Foo",
+            name="foo",
+            namespaced=True,
+            url="",
+            aliases=("foo",),
+            preferred=False,
+        )
+        meta = MetaManifest("", "foo", "", "")
+
+        def res(ver: str) -> K8sResource:
+            return r_foo._replace(apiVersion=f"api-a.com/{ver}")
+
+        # Stable: v10 beats v2 (numeric, not lexicographic).
+        r_v2, r_v10 = res("v2"), res("v10")
+        got, err = k8s.pick_api(meta, {"foo": [r_v2, r_v10]})
+        assert not err and got is r_v10
+
+        # Beta: v1beta10 beats v1beta2.
+        r_b2, r_b10 = res("v1beta2"), res("v1beta10")
+        got, err = k8s.pick_api(meta, {"foo": [r_b2, r_b10]})
+        assert not err and got is r_b10
+
+        # Alpha: a double-digit major (v10alpha1) beats v9alpha1.
+        r_a9, r_a10 = res("v9alpha1"), res("v10alpha1")
+        got, err = k8s.pick_api(meta, {"foo": [r_a9, r_a10]})
+        assert not err and got is r_a10
+
 
 class TestK8sKubeconfig:
     @mock.patch.object(k8s.os, "getenv")


### PR DESCRIPTION
When the cluster offers no preferred version, `pick_api` falls back to a heuristic that picks the highest stable/beta/alpha version. It sorted each tier as strings, so `v10` ranked below `v2` and a double-digit version could be passed over for a lower one. Sort each tier by its numeric components instead.

Behavior is unchanged for every single-digit version (numeric and string order coincide there); the tier precedence and the non-canonical fallback are untouched.
