### PR TITLE
bugfix: JSON path based element removal is now robust with 10+ elements.

### DIFF
--- a/square/manio_filters.py
+++ b/square/manio_filters.py
@@ -1,8 +1,23 @@
 import copy
+import re
 import square.dtypes
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import jsonpath_ng as jp
+
+
+def _natural_path_key(match: jp.DatumInContext) -> List[Union[int, str]]:
+    """Return a natural-sort key for a JSONPath match.
+
+    Splitting the path string on digit runs and parsing those runs as integers
+    makes array indices sort numerically (eg "[10]" after "[9]") rather than
+    lexicographically. `re.split` alternates non-digit and digit chunks, so a
+    given position is always the same type across keys and the lists compare
+    without mixing `int` and `str`.
+
+    """
+    parts = re.split(r"(\d+)", str(match.full_path))
+    return [int(part) if part.isdigit() else part for part in parts]
 
 
 def remove_empty_dicts(data: Any) -> Any:
@@ -75,11 +90,13 @@ def strip_manifest_paths(manifest: Dict[str, Any], paths: List[str]) -> Dict[str
 
     # Collect all matches across all expressions, then sort by index descending
     # so that deleting array elements by index doesn't shift subsequent indices.
+    # The key must order indices numerically, otherwise "[10]" sorts before
+    # "[9]" and deleting from a >=10 element array raises an IndexError.
     all_matches: List[jp.DatumInContext] = []
     jpathcache = square.dtypes.jpcache
     for path in paths:
         all_matches.extend(jpathcache(path).find(manifest))
-    all_matches.sort(key=lambda m: str(m.full_path), reverse=True)
+    all_matches.sort(key=_natural_path_key, reverse=True)
 
     for jpmatch in all_matches:
         _delete_match(jpmatch)

--- a/tests/test_manio_filters.py
+++ b/tests/test_manio_filters.py
@@ -171,6 +171,29 @@ def test_array_index_stripping_multi():
     }
 
 
+def test_array_index_stripping_double_digit():
+    """Deleting array elements must order indices numerically, not as strings.
+
+    A string sort ranks "[2]" above "[11]", so deleting index 2 first shrinks
+    the list and the later `del arr[11]` raises IndexError. Arrays with fewer
+    than ten elements are only coincidentally safe.
+
+    """
+    # Surgical case: delete a single- and a double-digit index. String-sorting
+    # would delete [2] before [11] and then crash.
+    manifest = {"spec": {"containers": [{"name": f"c{i}"} for i in range(12)]}}
+    result = strip_manifest_paths(
+        manifest, ["spec.containers[2]", "spec.containers[11]"]
+    )
+    kept = [i for i in range(12) if i not in (2, 11)]
+    assert result == {"spec": {"containers": [{"name": f"c{i}"} for i in kept]}}
+
+    # Wildcard over a 12-element array must strip them all without crashing.
+    manifest = {"spec": {"containers": [{"name": f"c{i}"} for i in range(12)]}}
+    result = strip_manifest_paths(manifest, ["spec.containers[*]"])
+    assert result == {"spec": {"containers": []}}
+
+
 def test_wildcard_stripping():
     manifest = {
         "spec": {


### PR DESCRIPTION
strip_manifest_paths deleted matched elements in reverse order of their `JSONPath` string. String order ranks `[2]` above `[11]`, so deleting a lower single-digit index first shrank the list and a later `del arr[11]` raised `IndexError` on any array with 10+ elements. Sort by a natural key that parses the numeric path components as integers instead.
