### PR TITLE
Bugfix validation

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, NamedTuple, Set, Tuple
 
 import jsonpath_ng as jp
-from jsonpath_ng.exceptions import JsonPathParserError
+from jsonpath_ng.exceptions import JSONPathError
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import Annotated
@@ -429,7 +429,10 @@ class Config(BaseModel):
             try:
                 for path in paths:
                     jpcache(path)
-            except JsonPathParserError:
+            except JSONPathError:
+                # Catch the common base so both parser- and lexer-level errors
+                # (eg `JsonPathLexerError` from "!!invalid") surface as a clean
+                # ValueError instead of escaping as a raw traceback.
                 raise ValueError(f"invalid JSON path <{path}>")
 
         return out

--- a/square/main.py
+++ b/square/main.py
@@ -327,8 +327,11 @@ def compile_config(cmdline_param) -> Tuple[Config, bool]:
     # ------------------------------------------------------------------------
     # Verify inputs.
     # ------------------------------------------------------------------------
-    # Abort without credentials.
-    if not kubeconfig.exists():
+    # Abort without credentials. Require an actual file: an empty kubeconfig
+    # value parses to `Path('.')`, which `.exists()` accepts (the CWD) but
+    # `.is_file()` correctly rejects, so we abort here instead of failing later
+    # with a confusing K8s loading error.
+    if not kubeconfig.is_file():
         logit.error(f"Cannot find Kubernetes config file <{kubeconfig}>")
         return err_resp
 

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -284,6 +284,17 @@ class TestConfigFilters:
         with pytest.raises(pydantic.ValidationError):
             self.make_config({"deployment": ["]$0metadata.labels"]})
 
+    def test_filters_invalid_path_lexer_error(self):
+        """A lexer-level JSON path error must also raise a ValidationError.
+
+        `!!invalid` raises `JsonPathLexerError`, which is not a subclass of
+        `JsonPathParserError`; without catching it too, it escaped Config
+        construction as a raw traceback.
+
+        """
+        with pytest.raises(pydantic.ValidationError):
+            self.make_config({"deployment": ["!!invalid"]})
+
     def test_filters_valid_key_with_group(self):
         """A key with an explicit API group is valid."""
         res = "role.rbac.authorization.k8s.io"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -408,6 +408,29 @@ class TestMain:
                 else:
                     assert err
 
+    def test_compile_config_empty_kubeconfig_in_configfile(self, fname_param_config):
+        """An empty `kubeconfig` in a `--config` file must abort cleanly.
+
+        `kubeconfig: ""` parses to `Path('.')`, which is truthy and whose
+        `.exists()` returns True. Without a proper file check Square would
+        proceed with a bogus kubeconfig and fail later with a confusing K8s
+        loading error instead of aborting here.
+
+        """
+        fname_config, param, _ = fname_param_config
+
+        data = yaml.safe_load(fname_config.read_text())
+        data["kubeconfig"] = ""
+        fname_config.write_text(yaml.dump(data))
+
+        # Use the config file explicitly (the `--config` branch) and provide no
+        # `--kubeconfig`, so the empty config value is all Square has.
+        param.configfile = str(fname_config)
+        param.kubeconfig = None
+
+        _, err = main.compile_config(param)
+        assert err
+
     def test_compile_config_kinds_clear_existing(self, fname_param_config):
         """Empty list on command line must clear the option."""
         _, param, _ = fname_param_config


### PR DESCRIPTION
Mostly TLC to catch a wider range of `JSONPath` errors and abort if the user points Square to a folder instead of a file.