### PR TITLE
refactor: give each K8sConfig its own httpx client

### DIFF
--- a/square/dtypes.py
+++ b/square/dtypes.py
@@ -233,11 +233,23 @@ class K8sConfig(BaseModel):
     headers: Dict[str, str] = {}
 
     # HttpX client to access the cluster. The `k8s.create_httpx_client` will
-    # replace it with a properly configured client.
-    client: httpx.AsyncClient = httpx.AsyncClient()
+    # replace it with a properly configured client. Use a `default_factory` so
+    # every instance gets its own client rather than sharing a single one
+    # created at import time.
+    client: httpx.AsyncClient = Field(default_factory=httpx.AsyncClient)
 
     # Kubernetes API endpoints (see `k8s.compile_api_endpoints`).
     apis: Dict[str, List[K8sResource]] = {}
+
+    def __eq__(self, other: object) -> bool:
+        # The httpx client is transient transport, not part of a config's
+        # identity, so exclude it from equality. This keeps the `(result, err)`
+        # convention's `K8sConfig()` error sentinels comparable even though each
+        # now carries its own client instance.
+        if not isinstance(other, K8sConfig):
+            return NotImplemented
+        fields = (name for name in type(self).model_fields if name != "client")
+        return all(getattr(self, name) == getattr(other, name) for name in fields)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,14 +1,39 @@
 from pathlib import Path
+import httpx
 import pydantic
 import pytest
 
 from square.dtypes import (
     Config,
+    K8sConfig,
     MetaManifest,
     Selectors,
     SelKindGroupNames,
     SelKindGroupNames as SKGN,
 )
+
+
+class TestK8sConfig:
+    def test_client_not_shared_between_instances(self):
+        """Each `K8sConfig` must get its own httpx client, not a shared one."""
+        a, b = K8sConfig(), K8sConfig()
+        assert a.client is not b.client
+        assert isinstance(a.client, httpx.AsyncClient)
+
+    def test_equality_ignores_client(self):
+        """Equality must ignore the transient httpx client.
+
+        The `(result, err)` convention returns `K8sConfig()` sentinels that
+        callers compare for equality, so two configs that differ only in their
+        (transient) client object must still compare equal. A difference in any
+        real field must still make them unequal.
+
+        """
+        assert K8sConfig() == K8sConfig()
+        assert K8sConfig(url="a") != K8sConfig(url="b")
+
+        # A config compared against a non-K8sConfig is never equal.
+        assert K8sConfig() != 42
 
 
 class TestSelectors:


### PR DESCRIPTION
The client field used a mutable default evaluated once at import, so `Pydantic` shared a single `AsyncClient` across every directly-constructed `K8sConfig` (a.client is b.client) and never closed it. Now the code uses a default_factory so each instance gets its own client.