### PR TITLE
refactor: utilise `httpx.Request` to streamline the retry logic

### DIFF
--- a/square/k8s.py
+++ b/square/k8s.py
@@ -10,7 +10,6 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
-from urllib.parse import urlparse
 
 import httpx
 import tenacity as tc
@@ -41,10 +40,11 @@ logit = logging.getLogger("square")
 def _on_backoff(retry_state: tc.RetryCallState):
     """Log a warning on each retry."""
     attempt = retry_state.attempt_number
-    k8sconfig, method, url = retry_state.args[:3]
-    path = urlparse(url).path
+    k8sconfig, request = retry_state.args
 
-    logit.warning(f"Back off {attempt} - {k8sconfig.name} - {method} {path}.")
+    logit.warning(
+        f"Back off {attempt} - {k8sconfig.name} - {request.method} {request.url.path}."
+    )
 
 
 async def _mysleep(delay: float):
@@ -60,14 +60,8 @@ async def _mysleep(delay: float):
     reraise=True,
     sleep=_mysleep,
 )
-async def _call(
-    k8sconfig: K8sConfig,
-    method: str,
-    url: str,
-    payload: dict | list | None,
-    headers: dict | None,
-) -> httpx.Response:
-    return await k8sconfig.client.request(method, url, json=payload, headers=headers)
+async def _call(k8sconfig: K8sConfig, request: httpx.Request) -> httpx.Response:
+    return await k8sconfig.client.send(request)
 
 
 async def request(
@@ -93,9 +87,13 @@ async def request(
         (dict, int, bool): the JSON response and the HTTP status code.
 
     """
-    # Make the HTTP request via our backoff/retry handler.
+    # Build the request up front so the retry/backoff handler can send it
+    # verbatim on each attempt. We use `client.build_request` rather than the
+    # bare `httpx.Request` constructor so the client's default headers (most
+    # notably the bearer token) are merged into the request.
+    request = k8sconfig.client.build_request(method, url, json=payload, headers=headers)
     try:
-        ret = await _call(k8sconfig, method, url, payload=payload, headers=headers)
+        ret = await _call(k8sconfig, request)
     except WEB_EXCEPTIONS as err:
         logit.error(f"Giving up - {k8sconfig.name} - {err} - {method} {url}")
         return ({}, -1, True)

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -162,6 +162,32 @@ class TestK8sDeleteGetPatchPost:
         assert ret == (response, status_code, False)
 
     @pytest.mark.parametrize("method", ("DELETE", "GET", "PATCH", "POST"))
+    async def test_request_carries_client_default_headers(
+        self, method, k8sconfig: K8sConfig, respx_mock
+    ):
+        """The client's default headers (eg the bearer token) must reach the wire.
+
+        The auth token lives as a default header on the `httpx` client, not on
+        the individual request. This guards against building the request in a
+        way that bypasses that merge (eg the bare `httpx.Request` constructor).
+
+        """
+        url = "http://examples.com/"
+
+        # Put a default header on the client, exactly as `create_httpx_client`
+        # does for the bearer token.
+        k8sconfig.client.headers.update({"authorization": "Bearer token"})
+
+        m_http = respx_mock.request(method, url)
+        m_http.return_value = httpx.Response(200, json={})
+
+        await k8s.request(k8sconfig, method, url, None, None)
+
+        # The outgoing request must carry the client's default header.
+        sent = m_http.calls.last.request
+        assert sent.headers["authorization"] == "Bearer token"
+
+    @pytest.mark.parametrize("method", ("DELETE", "GET", "PATCH", "POST"))
     async def test_request_err_json(self, method, k8sconfig: K8sConfig, respx_mock):
         """Simulate a corrupt JSON response from K8s."""
         # Dummies for K8s API URL and `httpx` client.
@@ -209,16 +235,17 @@ class TestK8sDeleteGetPatchPost:
 
         # Trick: we cannot mock any of the `Tenacity` callback functions
         # because they are imported before PyTest can patch them. Therefore, we
-        # will mock `urlparse` as a proxy since it is not used anywhere else
-        # and can tell us the number of invocations.
-        with mock.patch.object(k8s, "urlparse") as m_proxy:
+        # mock the module logger as a proxy: `_on_backoff` emits exactly one
+        # warning per retry, so its `warning` count tells us how often we backed
+        # off.
+        with mock.patch.object(k8s, "logit") as m_logit:
             # Test function must return an empty response and an error.
             ret = await k8s.request(k8sconfig, method, url, None, None)
             assert ret == ({}, -1, True)
 
-            # Callback must have been called 7 times because Square
+            # Backoff callback must have fired 7 times because Square
             # set `stop_after_attempt(8)`.
-            assert m_proxy.call_count == 7
+            assert m_logit.warning.call_count == 7
 
     @pytest.mark.parametrize("method", ("DELETE", "GET", "PATCH", "POST"))
     async def test_request_invalid(self, method, k8sconfig):


### PR DESCRIPTION
NoOp. Just a neater way to implement the retry logic.